### PR TITLE
Deal with windows being weird about names sometimes

### DIFF
--- a/test/main.jl
+++ b/test/main.jl
@@ -20,7 +20,7 @@ withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
          fetch_method=dummydown
         )
 
-        @test basename(datadep"Test1") == "Test1"
+        @test endswith(datadep"Test1", "Test1") || endswith(datadep"Test1", "Test1/") ||  endswith(datadep"Test1", "Test1\\")
 
         @test all_expectations_used(dummyhash)
         @test all_expectations_used(dummydown)


### PR DESCRIPTION
I can't reproduce this failure on my local windows boxes,
but I believe this is the solution.

Lets see what AppVeyor thinks