### PR TITLE
 `RegisterDataDep(...)` -> `register(DataDep(...))` and expost `resolve`

### DIFF
--- a/src/DataDeps.jl
+++ b/src/DataDeps.jl
@@ -5,81 +5,12 @@ using HTTP
 using Reexport
 @reexport using SHA
 
-export RegisterDataDep, @datadep_str, unpack
+export DataDep, ManualDataDep
+export register, resolve, @datadep_str
+export unpack
 
-abstract type AbstractDataDep end
 
-"""
-    ManualDataDep(name, message)
-
-"""
-struct ManualDataDep <: AbstractDataDep
-    name::String
-    message::String
-end
-
-struct DataDep{H, R, F, P} <: AbstractDataDep
-    name::String
-    remotepath::R
-    hash::H
-    fetch_method::F
-    post_fetch_method::P
-    extra_message::String
-end
-
-macro datadep_str(path)
-    quote
-        parts = splitpath($(esc(path)))
-        name = first(parts)
-        inner_path = length(parts) > 1 ? joinpath(Iterators.drop(parts, 1)...) : ""
-        resolve(registry[name], inner_path, @__FILE__)
-    end
-end
-
-"""
-    resolve(datadep, inner_filepath, calling_filepath)
-
-Returns a path to the folder containing the datadep.
-Even if that means downloading the dependancy and putting it in there.
-
-     - `inner_filepath` is the path to the file within the data dir
-     - `calling_filepath` is a path to the file where this is being invoked from
-
-This is basically the function the lives behind the string macro `datadep"DepName/inner_filepath"`.
-"""
-function resolve(datadep::AbstractDataDep, inner_filepath, calling_filepath)::String
-    while true
-        dirpath = _resolve(datadep, calling_filepath)
-        filepath = joinpath(dirpath, inner_filepath)
-        
-        if can_read_file(filepath)
-            return realpath(filepath) # resolve any symlinks for maximum compatibility with external applications
-        else # Something has gone wrong
-            warn("DataDep $(datadep.name) found at \"$(dirpath)\". But could not read file at \"$(filepath)\".")
-            warn("Something has gone wrong. What would you like to do?")
-            input_choice(
-                ('A', "Abort -- this will error out",
-                    ()->error("Aborted resolving data dependency, program could not continue.")),
-                ('R', "Retry -- do this after fixing the problem outside of this script", 
-                    ()->nothing), # nothing to do
-                ('X', "Remove directory and retry  -- will retrigger download if there isn't another copy elsewhere",
-                    ()->rm(dirpath, force=true, recursive=true);
-                )
-            )
-        end
-    end
-end
-
-"The core of the resolve function without any user friendly stuff, returns the directory"
-function _resolve(datadep::AbstractDataDep, calling_filepath)::String
-    lp = try_determine_load_path(datadep.name, calling_filepath)
-    dirpath = if !isnull(lp)
-        get(lp)
-    else
-        handle_missing(datadep, calling_filepath)
-    end
-end
-
+include("types.jl")
 
 include("util.jl")
 include("registration.jl")
@@ -88,10 +19,11 @@ include("filename_solving.jl")
 include("locations.jl")
 include("verification.jl")
 
-
+include("resolution.jl")
 include("resolution_automatic.jl")
 include("resolution_manual.jl")
 
 include("helpers.jl")
+include("deprecations.jl")
 
 end # module

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,23 @@
+# This file is a part of DataDeps.jl. License is MIT.
+
+@deprecate(
+    RegisterDataDep(name::String,
+        message::String,
+        remotepath,
+        hash=nothing;
+        fetch_method=download,
+        post_fetch_method=identity,
+    ),
+    register(DataDep(name::String,
+        message::String,
+        remotepath,
+        hash;
+        fetch_method=fetch_method,
+        post_fetch_method=post_fetch_method)
+    )
+)
+
+@deprecate(
+    RegisterDataDep(name::String, message::String),
+    register(ManualDataDep(name, message))
+)

--- a/src/registration.jl
+++ b/src/registration.jl
@@ -2,25 +2,18 @@
 
 const registry = Dict{String, AbstractDataDep}()
 
-function RegisterDataDep(name::String,
-        message::String,
-        remotepath,
-        hash=nothing;
-        fetch_method=download,
-        post_fetch_method=identity,
-    )
+function register(datadep::AbstractDataDep)
+    name = datadep.name
     if haskey(registry, name)
         warn("Over-writing registration of the datadep: $name")
     end
-    registry[name] = DataDep(name,remotepath,hash,fetch_method,post_fetch_method, message)
+    if !is_valid_name(name)
+        error(name, " is not a valid name for a datadep. Valid names must be legal foldernames on Windows.")
+    end
+
+    registry[name] = datadep
 end
 
-function RegisterDataDep(name::String, message::String)
-    if haskey(registry, name)
-        warn("Over-writing registration of the datadep: $name")
-    end
-    registry[name] = ManualDataDep(name, message)
-end
 
 """
     is_valid_name(name)
@@ -31,5 +24,5 @@ This basically means it must be a valid folder name on windows.
 """
 function is_valid_name(name)
     namechars = collect(name)
-    !any( namechars .∈ "\\/:*?<>|") && !any(Base.UTF8prox.iscntrl.(namechars))
+    !any( namechars .∈ "\\/:*?<>|") && !any(iscntrl.(namechars))
 end

--- a/src/resolution.jl
+++ b/src/resolution.jl
@@ -1,0 +1,74 @@
+# This file is a part of DataDeps.jl. License is MIT.
+
+"""
+    `datadep"Name"` or `datadep"Name/file"`
+
+Use this just like you would a file path, except that you can refer by name to the datadep.
+The name alone will resolve to the corresponding folder.
+Even if that means it has to be downloaded first.
+Adding a path within it functions as expected.
+"""
+macro datadep_str(path)
+    quote
+        parts = splitpath($(esc(path)))
+        name = first(parts)
+        inner_path = length(parts) > 1 ? joinpath(Iterators.drop(parts, 1)...) : ""
+        resolve(name, inner_path, @__FILE__)
+    end
+end
+
+
+
+
+"""
+    resolve(datadep, inner_filepath, calling_filepath)
+
+Returns a path to the folder containing the datadep.
+Even if that means downloading the dependancy and putting it in there.
+
+     - `inner_filepath` is the path to the file within the data dir
+     - `calling_filepath` is a path to the file where this is being invoked from
+
+This is basically the function the lives behind the string macro `datadep"DepName/inner_filepath"`.
+"""
+function resolve(datadep::AbstractDataDep, inner_filepath, calling_filepath)::String
+    while true
+        dirpath = _resolve(datadep, calling_filepath)
+        filepath = joinpath(dirpath, inner_filepath)
+
+        if can_read_file(filepath)
+            return realpath(filepath) # resolve any symlinks for maximum compatibility with external applications
+        else # Something has gone wrong
+            warn("DataDep $(datadep.name) found at \"$(dirpath)\". But could not read file at \"$(filepath)\".")
+            warn("Something has gone wrong. What would you like to do?")
+            input_choice(
+                ('A', "Abort -- this will error out",
+                    ()->error("Aborted resolving data dependency, program could not continue.")),
+                ('R', "Retry -- do this after fixing the problem outside of this script",
+                    ()->nothing), # nothing to do
+                ('X', "Remove directory and retry  -- will retrigger download if there isn't another copy elsewhere",
+                    ()->rm(dirpath, force=true, recursive=true);
+                )
+            )
+        end
+    end
+end
+
+"""
+Passing resolve a string rather than an actual datadep object works to look up
+the data dep from the registry.
+This is useful for progammatic downloading.
+"""
+function resolve(datadep_name::AbstractString, inner_filepath, calling_filepath)::String
+    resolve(registry[datadep_name], inner_filepath, calling_filepath)
+end
+
+"The core of the resolve function without any user friendly stuff, returns the directory"
+function _resolve(datadep::AbstractDataDep, calling_filepath)::String
+    lp = try_determine_load_path(datadep.name, calling_filepath)
+    dirpath = if !isnull(lp)
+        get(lp)
+    else
+        handle_missing(datadep, calling_filepath)
+    end
+end

--- a/src/resolution.jl
+++ b/src/resolution.jl
@@ -49,16 +49,24 @@ function resolve(datadep::AbstractDataDep, inner_filepath, calling_filepath)::St
     end
 end
 
-"""
-Passing resolve a string rather than an actual datadep object works to look up
-the data dep from the registry.
-This is useful for progammatic downloading.
-"""
+
 function resolve(datadep_name::AbstractString, inner_filepath, calling_filepath)::String
     resolve(registry[datadep_name], inner_filepath, calling_filepath)
 end
 
-function resolve(namepath::AbstractString, calling_filepath=nothing)
+"""
+    resolve("name/path", @__FILE__)
+
+Is the function that lives directly behind the `datadep"name/path"` macro.
+If you are working the the names of the datadeps programatically,
+and don't want to download them by mistake;
+it can be easier to work with this function.
+
+Note though that you must include `@__FILE__` as the second argument,
+as DataDeps.jl uses this to allow reading the package specific `deps/data` directory.
+Advanced usage could specify a different file or `nothing`, but at that point you are on your own.
+"""
+function resolve(namepath::AbstractString, calling_filepath)
     parts = splitpath(namepath)
     name = first(parts)
     inner_path = length(parts) > 1 ? joinpath(Iterators.drop(parts, 1)...) : ""

--- a/src/resolution.jl
+++ b/src/resolution.jl
@@ -8,16 +8,11 @@ The name alone will resolve to the corresponding folder.
 Even if that means it has to be downloaded first.
 Adding a path within it functions as expected.
 """
-macro datadep_str(path)
+macro datadep_str(namepath)
     quote
-        parts = splitpath($(esc(path)))
-        name = first(parts)
-        inner_path = length(parts) > 1 ? joinpath(Iterators.drop(parts, 1)...) : ""
-        resolve(name, inner_path, @__FILE__)
+        resolve($(esc(namepath)), @__FILE__)
     end
 end
-
-
 
 
 """
@@ -63,7 +58,15 @@ function resolve(datadep_name::AbstractString, inner_filepath, calling_filepath)
     resolve(registry[datadep_name], inner_filepath, calling_filepath)
 end
 
-"The core of the resolve function without any user friendly stuff, returns the directory"
+function resolve(namepath::AbstractString, calling_filepath=nothing)
+    parts = splitpath(namepath)
+    name = first(parts)
+    inner_path = length(parts) > 1 ? joinpath(Iterators.drop(parts, 1)...) : ""
+    resolve(name, inner_path, calling_filepath)
+end
+
+
+"The core of the resolve function without any user friendly file stuff, returns the directory"
 function _resolve(datadep::AbstractDataDep, calling_filepath)::String
     lp = try_determine_load_path(datadep.name, calling_filepath)
     dirpath = if !isnull(lp)

--- a/src/resolution_automatic.jl
+++ b/src/resolution_automatic.jl
@@ -147,7 +147,6 @@ end
 function check_if_accept_terms(datadep::DataDep, localpath, remotepath)
     info("This program has requested access to the data dependency $(datadep.name).")
     info("which is not currently installed. It can be installed automatically, and you will not see this message again.")
-    info(datadep.extra_message)
-    info("\n")
+    info("\n",datadep.extra_message,"\n\n")
     input_bool("Do you want to download the dataset from $remotepath to \"$localpath\"?")
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,0 +1,83 @@
+# This file is a part of DataDeps.jl. License is MIT.
+
+
+abstract type AbstractDataDep end
+
+"""
+    ManualDataDep(name, message)
+
+A DataDep for if the installation needs to be handled manually.
+This can be done via Pkg/git if you put the dependency into the packages repo's `/deps/data` directory.
+More generally, message should give instructions on how to setup the data.
+"""
+struct ManualDataDep <: AbstractDataDep
+    name::String
+    message::String
+end
+
+struct DataDep{H, R, F, P} <: AbstractDataDep
+    name::String
+    remotepath::R
+    hash::H
+    fetch_method::F
+    post_fetch_method::P
+    extra_message::String
+end
+
+
+
+"""
+```
+DataDep(
+    name::String,
+    message::String,
+    remote_path::Union{String,Vector{String}...},
+    [checksum::Union{String,Vector{String}...},]; # Optional, if not provided will generate
+    # keyword args (Optional):
+    fetch_method=download # (remote_filepath, local_filepath)->Any
+    post_fetch_method=download # (local_filepath)->Any
+)
+```
+
+#### Required Fields
+
+ - *Name**: the name used to refer to this datadep, coresponds to a folder name where it will be stored
+    - It can have spaces or any other character that is allowed in a Windows filestring (which is a strict subset of the restriction for unix filenames).
+ - *Message*: A message displayed to the user for they are asked if they want to downloaded it.
+    - This is normally used to give a link to the original source of the data, a paper to be cited etc.
+ - *remote_path*: where to fetch the data from. Normally a string or strings) containing an URL
+    - This is usually a string, or a vector of strings (or a vector of vector... see [Recursive Structure](Recursive Structure) below)
+
+#### Optional Fields
+ - *checksum* this is very flexible, it is used to check the files downloaded correctly
+    - By far the most common use is to just provide a SHA256 sum as a hex-string for the files
+    - If not provided, then a warning message with the  SHA256 sum is displayed. This is to help package devs workout the sum for there files, without using an external tool.
+    - If you want to use a different hashing algorithm, then you can provide a tuple `(hashfun, targethex)`
+        - `hashfun` should be a function which takes an IOStream, and returns a `Vector{UInt8}`.
+	      - Such as any of the functions from [SHA.jl](https://github.com/staticfloat/SHA.jl), eg `sha3_384`, `sha1_512`
+	      - or `md5` from [MD5.jl](https://github.com/oxinabox/MD5.jl)
+  - If you want to use a different hashing algorithm, but don't know the sum, you can provide just the `hashfun` and a warning message will be displayed, giving the correct tuple of `(hashfun, targethex)` that should be added to the registration block.
+
+	- If you don't want to provide a checksum,  because your data can change pass in the type `Any` which will suppress the warning messages. (But see above warnings about "what if my data is dynamic")
+    - Can take a vector of checksums, being one for each file, or a single checksum in which case the per file hashes are `xor`ed to get the target hash. (See [Recursive Structure](Recursive Structure) below)
+
+
+ -  `fetch_method=download` a function to run to download the files.
+    - Function should take 2 parameters (remote_fikepath, local_filepath), and can return anything
+    - Defaults to `Base.download` which invokes commandline download tools.
+    - Can take a vector of methods, being one for each file, or a single method, in which case that method is used to download all of them. (See [Recursive Structure](Recursive Structure) below)
+    - Very few people will need to override this, but potentially it can be used to deal with things like authorisation (let me know if you try)
+
+ - `post_fetch_method` a function to run after the files have download
+    - Should take the local filepath as its first and only argument. Can return anything.
+    - Default is to do nothing.
+    - Can do what it wants from there, but most likes wants to extract the file into the data directory.
+    - towards this end DataDeps includes a command: `unpack` which will extract an compressed folder, deleting the original.
+    - It should be noted that it `post_fetch_method` runs from within the data directory
+       - which means operations that just write to the current working directory (like `rm` or `mv` or ```run(`SOMECMD`))``` just work.
+       - You can call `cwd()` to get the the data directory for your own functions. (Or `dirname(local_filepath)`)
+    - Can take a vector of methods, being one for each file, or a single method, in which case that ame method is applied to all of the files. (See **Recursive Structure** in the README.md)
+"""
+function DataDep(name::String, message::String, remotepath, hash=nothing; fetch_method=download, post_fetch_method=identity)
+    DataDep(name, remotepath, hash, fetch_method, post_fetch_method, message)
+end

--- a/test/deprecated_examples.jl
+++ b/test/deprecated_examples.jl
@@ -1,0 +1,234 @@
+using Base.Test
+using DataDeps
+
+ENV["DATADEPS_ALWAY_ACCEPT"]=true
+
+@testset "Pi" begin
+    RegisterDataDep(
+     "Pi",
+     "There is no real reason to download Pi, unlike say lists of prime numbers, it is always faster to compute than it is to download. No matter how many digits you want.",
+     "https://www.angio.net/pi/digits/10000.txt",
+     sha2_256
+    )
+
+    pi_string = readstring(datadep"Pi/10000.txt")
+    @test parse(pi_string) ≈ π
+    @test parse(BigFloat, pi_string) ≈ π
+
+end
+
+@testset "Primes" begin
+    RegisterDataDep(
+     "Primes",
+     "These are the first 65 thousand primes. Still faster to calculate locally.",
+     "http://staffhome.ecm.uwa.edu.au/~00061811/pub/primes.txt",
+
+     "d6524d63a5cf5e5955568cc96b72b3f39258af4f0f79c61cbc01d8853e587f1b"
+     #Important: this is a hash I didn't calculate, so is a test that our checksum methods actually align with the normal values.
+    )
+
+    data = readdlm(datadep"Primes/primes.txt", ',')
+    primes = data[4:end, 2] #skip fist 3
+
+    #If these really are prime then will not have factors
+    @test !any(isinteger.(primes./2))
+    @test !any(isinteger.(primes./3))
+    @test !any(isinteger.(primes./5))
+
+end
+
+
+@testset "TrumpTweets" begin
+    # This tests demostrates how the `post_fetch_method` can be used to synthesize new files
+
+    RegisterDataDep("TrumpTweets",
+    """
+    Tweets from 538's article:
+    [The World’s Favorite Donald Trump Tweets](https://fivethirtyeight.com/features/the-worlds-favorite-donald-trump-tweets/)
+
+    Includes a filtered view that is the tweats filtered to remove any tweets that @mention anyone,
+    so no conversations etc, just announcements of opinions/thoughts.
+
+    Used under Creative Commons Attribution 4.0 International License.
+    """,
+    "https://raw.githack.com/fivethirtyeight/data/master/trump-twitter/realDonaldTrump_poll_tweets.csv",
+    "5a63b6cb2503a20517b5d41bd73e821ffbfdddd5cdc1977a547f1c925790bb15",
+    post_fetch_method = function(in_fn) # Multiline anon function.
+        out_fn = "nonmentions_"*basename(in_fn)
+        print(out_fn)
+        open(out_fn, "w") do out_fh
+            for line in eachline(in_fn)
+                if !contains(line, "@")
+                    println(out_fh, line)
+                end
+            end
+        end
+
+    end
+    )
+
+    # Read the original file
+    all_tweets = Set(eachline(datadep"TrumpTweets/realDonaldTrump_poll_tweets.csv"))
+    # Read the file that we are generating
+    nonmentions_tweets = Set(eachline(datadep"TrumpTweets/nonmentions_realDonaldTrump_poll_tweets.csv"))
+    # Use them both
+    mentions_tweets = setdiff(all_tweets, nonmentions_tweets)
+    @test length(mentions_tweets) > 0
+    @test all(contains.(collect(mentions_tweets), "@"))
+end
+
+
+
+
+@testset "MNIST" begin
+
+    RegisterDataDep(
+        "MNIST train",
+        """
+        Dataset: THE MNIST DATABASE of handwritten digits, (training subset)
+        Authors: Yann LeCun, Corinna Cortes, Christopher J.C. Burges
+        Website: http://yann.lecun.com/exdb/mnist/
+        [LeCun et al., 1998a]
+            Y. LeCun, L. Bottou, Y. Bengio, and P. Haffner.
+            "Gradient-based learning applied to document recognition."
+            Proceedings of the IEEE, 86(11):2278-2324, November 1998
+        The files are available for download at the offical
+        website linked above. We can download these files for you
+        if you wish, but that doesn't free you from the burden of
+        using the data responsibly and respect copyright. The
+        authors of MNIST aren't really explicit about any terms
+        of use, so please read the website to make sure you want
+        to download the dataset.
+        """,
+        "http://yann.lecun.com/exdb/mnist/".*["train-images-idx3-ubyte.gz", "train-labels-idx1-ubyte.gz"];
+        # Not providing a checksum at all so can check it gives output
+        # TODO : automate this test with new 0.7 stuff
+    )
+
+
+    RegisterDataDep(
+        "MNIST",
+        """
+        Dataset: THE MNIST DATABASE of handwritten digits
+        Authors: Yann LeCun, Corinna Cortes, Christopher J.C. Burges
+        Website: http://yann.lecun.com/exdb/mnist/
+        [LeCun et al., 1998a]
+            Y. LeCun, L. Bottou, Y. Bengio, and P. Haffner.
+            "Gradient-based learning applied to document recognition."
+            Proceedings of the IEEE, 86(11):2278-2324, November 1998
+        The files are available for download at the offical
+        website linked above. We can download these files for you
+        if you wish, but that doesn't free you from the burden of
+        using the data responsibly and respect copyright. The
+        authors of MNIST aren't really explicit about any terms
+        of use, so please read the website to make sure you want
+        to download the dataset.
+        """,
+        "http://yann.lecun.com/exdb/mnist/".*["train-images-idx3-ubyte.gz", "train-labels-idx1-ubyte.gz", "t10k-images-idx3-ubyte.gz", "t10k-labels-idx1-ubyte.gz"],
+        "0bb1d5775d852fc5bb32c76ca15a7eb4e9a3b1514a2493f7edfcf49b639d7975"
+    )
+read(datadep"MNIST"*"/train-labels-idx1-ubyte.gz")
+    @test read(datadep"MNIST"*"/train-labels-idx1-ubyte.gz") == read(datadep"MNIST train"*"/train-labels-idx1-ubyte.gz")
+end
+
+
+@testset "UCI Banking" begin
+    RegisterDataDep(
+        "UCI Banking",
+        """
+        Dataset: Bank Marketing Data Set
+        Authors: S. Moro, P. Cortez and P. Rita.
+        Website: https://archive.ics.uci.edu/ml/datasets/bank+marketing
+
+        This dataset is public available for research. The details are described in [Moro et al., 2014].
+        Please include this citation if you plan to use this database:
+        [Moro et al., 2014] S. Moro, P. Cortez and P. Rita. A Data-Driven Approach to Predict the Success of Bank Telemarketing. Decision Support Systems, Elsevier, 62:22-31, June 2014
+        """,
+        [
+        "https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank.zip",
+        "https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank-additional.zip"
+        ],
+        [(SHA.sha1, "785118991cd7d7ee7d8bf75ea58b6fae969ac185"),
+         (SHA.sha3_224, "01b53f5b69d0b169070219b4391c623d84ab17d4cea8c8895cbf951d")];
+
+         post_fetch_method = file->run(`unzip $file`)
+    )
+
+    data, header = readdlm(datadep"UCI Banking/bank.csv", ';', header=true)
+    @test size(header) == (1,17)
+    @test size(data) == (4521,17)
+
+end
+
+
+@testset "UCI Adult, Hierarchical checksums" begin
+    # This is an example of using hierachacy in the remote URLs,
+    # and similar (partially matching up to depth) hierachacy in the checksums
+    # for processing some groups of elements differently to others.
+    # Doing this with checksums is not particularly useful
+    # But the same thing applies to `fetch_method` and `post_fetch_method`.
+    # So for example the
+    RegisterDataDep(
+        "UCI Adult",
+        """
+    	Dataset: Adult Data Set UCI ML Repository
+    	Website: https://archive.ics.uci.edu/ml/datasets/Adult
+    	Abstract : Predict whether income exceeds \$50K/yr based on census data.  Also known as "Census Income" dataset.
+
+    	If you make use of this data it is requested that you cite:
+    	- Lichman, M. (2013). UCI Machine Learning Repository [http://archive.ics.uci.edu/ml]. Irvine, CA: University of California, School of Information and Computer Science.
+    	""",
+        [
+            [
+                "https://archive.ics.uci.edu/ml/datasets/../machine-learning-databases/adult/adult.data",
+                "https://archive.ics.uci.edu/ml/datasets/../machine-learning-databases/adult/adult.test"
+            ],
+
+            [
+                "https://archive.ics.uci.edu/ml/datasets/../machine-learning-databases/adult/Index",
+                [
+                    "https://archive.ics.uci.edu/ml/datasets/../machine-learning-databases/adult/adult.names"
+                    "https://archive.ics.uci.edu/ml/datasets/../machine-learning-databases/adult/old.adult.names"
+                ]
+             ]
+        ],
+        [
+            "f9a9220df6bc5d9848bf450fd9ad45b9496503551af387d4a1bbe38ce1f8fc38", #adult.data ⊻ adult.test
+            [
+             "c53c35ce8a0eb10c12dd4b73830f3c94ae212bb388389d3763bce63e8d6bc684", #Index
+             "818481d320861c4b623626ff6fab3426ad93dae4434b7f54ca5a0f357169c362" # adult.names ⊻ old.adult.names
+            ]
+        ]
+    )
+
+    @test length(collect(eachline(datadep"UCI Adult/adult.names"))) == 110
+
+
+end
+
+
+@testset "Data.Gov Babynames" begin
+    RegisterDataDep(
+        "Baby Names",
+        """
+        Dataset: Baby Names from Social Security Card Applications-National Level Data
+        Website: https://catalog.data.gov/dataset/baby-names-from-social-security-card-applications-national-level-data
+        License: CC0
+
+        The data (name, year of birth, sex and number) are from a 100 percent sample of Social Security card applications after 1879.
+        """,
+        ["https://www.ssa.gov/oact/babynames/names.zip",
+        "https://catalog.data.gov/harvest/object/f8ab4d49-b6b4-47d8-b1bb-b18187094f35"
+         # Interestingly this metadata file fails on windows to resolve to filename to save to
+         # See warnings, The `mv` in post_fetch_method is the work-around.
+        ],
+        Any, # Test that there is no warning about checksum. This data is updated annually
+        #TODO : Automate this test with new 0.7 test_warn stuff
+        ;
+        post_fetch_method = [unpack, f->mv(f, "metadata551randstuff.json")]
+    )
+
+    @test !any(endswith.(readdir(datadep"Baby Names"), "zip"))
+    @test first(eachline(joinpath(datadep"Baby Names", "yob2016.txt")))=="Emma,F,19414"
+    @test filemode(joinpath(datadep"Baby Names", "metadata551randstuff.json")) > 0
+end

--- a/test/deprecated_examples_manual.jl
+++ b/test/deprecated_examples_manual.jl
@@ -1,0 +1,234 @@
+using Base.Test
+using DataDeps
+
+ENV["DATADEPS_ALWAY_ACCEPT"]=true
+
+@testset "Pi" begin
+    RegisterDataDep(
+     "Pi",
+     "There is no real reason to download Pi, unlike say lists of prime numbers, it is always faster to compute than it is to download. No matter how many digits you want.",
+     "https://www.angio.net/pi/digits/10000.txt",
+     sha2_256
+    )
+
+    pi_string = readstring(datadep"Pi/10000.txt")
+    @test parse(pi_string) ≈ π
+    @test parse(BigFloat, pi_string) ≈ π
+
+end
+
+@testset "Primes" begin
+    RegisterDataDep(
+     "Primes",
+     "These are the first 65 thousand primes. Still faster to calculate locally.",
+     "http://staffhome.ecm.uwa.edu.au/~00061811/pub/primes.txt",
+
+     "d6524d63a5cf5e5955568cc96b72b3f39258af4f0f79c61cbc01d8853e587f1b"
+     #Important: this is a hash I didn't calculate, so is a test that our checksum methods actually align with the normal values.
+    )
+
+    data = readdlm(datadep"Primes/primes.txt", ',')
+    primes = data[4:end, 2] #skip fist 3
+
+    #If these really are prime then will not have factors
+    @test !any(isinteger.(primes./2))
+    @test !any(isinteger.(primes./3))
+    @test !any(isinteger.(primes./5))
+
+end
+
+
+@testset "TrumpTweets" begin
+    # This tests demostrates how the `post_fetch_method` can be used to synthesize new files
+
+    RegisterDataDep("TrumpTweets",
+    """
+    Tweets from 538's article:
+    [The World’s Favorite Donald Trump Tweets](https://fivethirtyeight.com/features/the-worlds-favorite-donald-trump-tweets/)
+
+    Includes a filtered view that is the tweats filtered to remove any tweets that @mention anyone,
+    so no conversations etc, just announcements of opinions/thoughts.
+
+    Used under Creative Commons Attribution 4.0 International License.
+    """,
+    "https://raw.githack.com/fivethirtyeight/data/master/trump-twitter/realDonaldTrump_poll_tweets.csv",
+    "5a63b6cb2503a20517b5d41bd73e821ffbfdddd5cdc1977a547f1c925790bb15",
+    post_fetch_method = function(in_fn) # Multiline anon function.
+        out_fn = "nonmentions_"*basename(in_fn)
+        print(out_fn)
+        open(out_fn, "w") do out_fh
+            for line in eachline(in_fn)
+                if !contains(line, "@")
+                    println(out_fh, line)
+                end
+            end
+        end
+
+    end
+    )
+
+    # Read the original file
+    all_tweets = Set(eachline(datadep"TrumpTweets/realDonaldTrump_poll_tweets.csv"))
+    # Read the file that we are generating
+    nonmentions_tweets = Set(eachline(datadep"TrumpTweets/nonmentions_realDonaldTrump_poll_tweets.csv"))
+    # Use them both
+    mentions_tweets = setdiff(all_tweets, nonmentions_tweets)
+    @test length(mentions_tweets) > 0
+    @test all(contains.(collect(mentions_tweets), "@"))
+end
+
+
+
+
+@testset "MNIST" begin
+
+    RegisterDataDep(
+        "MNIST train",
+        """
+        Dataset: THE MNIST DATABASE of handwritten digits, (training subset)
+        Authors: Yann LeCun, Corinna Cortes, Christopher J.C. Burges
+        Website: http://yann.lecun.com/exdb/mnist/
+        [LeCun et al., 1998a]
+            Y. LeCun, L. Bottou, Y. Bengio, and P. Haffner.
+            "Gradient-based learning applied to document recognition."
+            Proceedings of the IEEE, 86(11):2278-2324, November 1998
+        The files are available for download at the offical
+        website linked above. We can download these files for you
+        if you wish, but that doesn't free you from the burden of
+        using the data responsibly and respect copyright. The
+        authors of MNIST aren't really explicit about any terms
+        of use, so please read the website to make sure you want
+        to download the dataset.
+        """,
+        "http://yann.lecun.com/exdb/mnist/".*["train-images-idx3-ubyte.gz", "train-labels-idx1-ubyte.gz"];
+        # Not providing a checksum at all so can check it gives output
+        # TODO : automate this test with new 0.7 stuff
+    )
+
+
+    RegisterDataDep(
+        "MNIST",
+        """
+        Dataset: THE MNIST DATABASE of handwritten digits
+        Authors: Yann LeCun, Corinna Cortes, Christopher J.C. Burges
+        Website: http://yann.lecun.com/exdb/mnist/
+        [LeCun et al., 1998a]
+            Y. LeCun, L. Bottou, Y. Bengio, and P. Haffner.
+            "Gradient-based learning applied to document recognition."
+            Proceedings of the IEEE, 86(11):2278-2324, November 1998
+        The files are available for download at the offical
+        website linked above. We can download these files for you
+        if you wish, but that doesn't free you from the burden of
+        using the data responsibly and respect copyright. The
+        authors of MNIST aren't really explicit about any terms
+        of use, so please read the website to make sure you want
+        to download the dataset.
+        """,
+        "http://yann.lecun.com/exdb/mnist/".*["train-images-idx3-ubyte.gz", "train-labels-idx1-ubyte.gz", "t10k-images-idx3-ubyte.gz", "t10k-labels-idx1-ubyte.gz"],
+        "0bb1d5775d852fc5bb32c76ca15a7eb4e9a3b1514a2493f7edfcf49b639d7975"
+    )
+read(datadep"MNIST"*"/train-labels-idx1-ubyte.gz")
+    @test read(datadep"MNIST"*"/train-labels-idx1-ubyte.gz") == read(datadep"MNIST train"*"/train-labels-idx1-ubyte.gz")
+end
+
+
+@testset "UCI Banking" begin
+    RegisterDataDep(
+        "UCI Banking",
+        """
+        Dataset: Bank Marketing Data Set
+        Authors: S. Moro, P. Cortez and P. Rita.
+        Website: https://archive.ics.uci.edu/ml/datasets/bank+marketing
+
+        This dataset is public available for research. The details are described in [Moro et al., 2014].
+        Please include this citation if you plan to use this database:
+        [Moro et al., 2014] S. Moro, P. Cortez and P. Rita. A Data-Driven Approach to Predict the Success of Bank Telemarketing. Decision Support Systems, Elsevier, 62:22-31, June 2014
+        """,
+        [
+        "https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank.zip",
+        "https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank-additional.zip"
+        ],
+        [(SHA.sha1, "785118991cd7d7ee7d8bf75ea58b6fae969ac185"),
+         (SHA.sha3_224, "01b53f5b69d0b169070219b4391c623d84ab17d4cea8c8895cbf951d")];
+
+         post_fetch_method = file->run(`unzip $file`)
+    )
+
+    data, header = readdlm(datadep"UCI Banking/bank.csv", ';', header=true)
+    @test size(header) == (1,17)
+    @test size(data) == (4521,17)
+
+end
+
+
+@testset "UCI Adult, Hierarchical checksums" begin
+    # This is an example of using hierachacy in the remote URLs,
+    # and similar (partially matching up to depth) hierachacy in the checksums
+    # for processing some groups of elements differently to others.
+    # Doing this with checksums is not particularly useful
+    # But the same thing applies to `fetch_method` and `post_fetch_method`.
+    # So for example the
+    RegisterDataDep(
+        "UCI Adult",
+        """
+    	Dataset: Adult Data Set UCI ML Repository
+    	Website: https://archive.ics.uci.edu/ml/datasets/Adult
+    	Abstract : Predict whether income exceeds \$50K/yr based on census data.  Also known as "Census Income" dataset.
+
+    	If you make use of this data it is requested that you cite:
+    	- Lichman, M. (2013). UCI Machine Learning Repository [http://archive.ics.uci.edu/ml]. Irvine, CA: University of California, School of Information and Computer Science.
+    	""",
+        [
+            [
+                "https://archive.ics.uci.edu/ml/datasets/../machine-learning-databases/adult/adult.data",
+                "https://archive.ics.uci.edu/ml/datasets/../machine-learning-databases/adult/adult.test"
+            ],
+
+            [
+                "https://archive.ics.uci.edu/ml/datasets/../machine-learning-databases/adult/Index",
+                [
+                    "https://archive.ics.uci.edu/ml/datasets/../machine-learning-databases/adult/adult.names"
+                    "https://archive.ics.uci.edu/ml/datasets/../machine-learning-databases/adult/old.adult.names"
+                ]
+             ]
+        ],
+        [
+            "f9a9220df6bc5d9848bf450fd9ad45b9496503551af387d4a1bbe38ce1f8fc38", #adult.data ⊻ adult.test
+            [
+             "c53c35ce8a0eb10c12dd4b73830f3c94ae212bb388389d3763bce63e8d6bc684", #Index
+             "818481d320861c4b623626ff6fab3426ad93dae4434b7f54ca5a0f357169c362" # adult.names ⊻ old.adult.names
+            ]
+        ]
+    )
+
+    @test length(collect(eachline(datadep"UCI Adult/adult.names"))) == 110
+
+
+end
+
+
+@testset "Data.Gov Babynames" begin
+    RegisterDataDep(
+        "Baby Names",
+        """
+        Dataset: Baby Names from Social Security Card Applications-National Level Data
+        Website: https://catalog.data.gov/dataset/baby-names-from-social-security-card-applications-national-level-data
+        License: CC0
+
+        The data (name, year of birth, sex and number) are from a 100 percent sample of Social Security card applications after 1879.
+        """,
+        ["https://www.ssa.gov/oact/babynames/names.zip",
+        "https://catalog.data.gov/harvest/object/f8ab4d49-b6b4-47d8-b1bb-b18187094f35"
+         # Interestingly this metadata file fails on windows to resolve to filename to save to
+         # See warnings, The `mv` in post_fetch_method is the work-around.
+        ],
+        Any, # Test that there is no warning about checksum. This data is updated annually
+        #TODO : Automate this test with new 0.7 test_warn stuff
+        ;
+        post_fetch_method = [unpack, f->mv(f, "metadata551randstuff.json")]
+    )
+
+    @test !any(endswith.(readdir(datadep"Baby Names"), "zip"))
+    @test first(eachline(joinpath(datadep"Baby Names", "yob2016.txt")))=="Emma,F,19414"
+    @test filemode(joinpath(datadep"Baby Names", "metadata551randstuff.json")) > 0
+end

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -4,12 +4,12 @@ using DataDeps
 ENV["DATADEPS_ALWAY_ACCEPT"]=true
 
 @testset "Pi" begin
-    RegisterDataDep(
+    register(DataDep(
      "Pi",
      "There is no real reason to download Pi, unlike say lists of prime numbers, it is always faster to compute than it is to download. No matter how many digits you want.",
      "https://www.angio.net/pi/digits/10000.txt",
      sha2_256
-    )
+    ))
 
     pi_string = readstring(datadep"Pi/10000.txt")
     @test parse(pi_string) ≈ π
@@ -18,14 +18,14 @@ ENV["DATADEPS_ALWAY_ACCEPT"]=true
 end
 
 @testset "Primes" begin
-    RegisterDataDep(
+    register(DataDep(
      "Primes",
      "These are the first 65 thousand primes. Still faster to calculate locally.",
      "http://staffhome.ecm.uwa.edu.au/~00061811/pub/primes.txt",
 
      "d6524d63a5cf5e5955568cc96b72b3f39258af4f0f79c61cbc01d8853e587f1b"
      #Important: this is a hash I didn't calculate, so is a test that our checksum methods actually align with the normal values.
-    )
+    ))
 
     data = readdlm(datadep"Primes/primes.txt", ',')
     primes = data[4:end, 2] #skip fist 3
@@ -40,8 +40,8 @@ end
 
 @testset "TrumpTweets" begin
     # This tests demostrates how the `post_fetch_method` can be used to synthesize new files
-    
-    RegisterDataDep("TrumpTweets",
+
+    register(DataDep("TrumpTweets",
     """
     Tweets from 538's article:
     [The World’s Favorite Donald Trump Tweets](https://fivethirtyeight.com/features/the-worlds-favorite-donald-trump-tweets/)
@@ -65,7 +65,7 @@ end
         end
 
     end
-    )
+    ))
 
     # Read the original file
     all_tweets = Set(eachline(datadep"TrumpTweets/realDonaldTrump_poll_tweets.csv"))
@@ -82,7 +82,7 @@ end
 
 @testset "MNIST" begin
 
-    RegisterDataDep(
+    register(DataDep(
         "MNIST train",
         """
         Dataset: THE MNIST DATABASE of handwritten digits, (training subset)
@@ -103,10 +103,10 @@ end
         "http://yann.lecun.com/exdb/mnist/".*["train-images-idx3-ubyte.gz", "train-labels-idx1-ubyte.gz"];
         # Not providing a checksum at all so can check it gives output
         # TODO : automate this test with new 0.7 stuff
-    )
+    ))
 
 
-    RegisterDataDep(
+    register(DataDep(
         "MNIST",
         """
         Dataset: THE MNIST DATABASE of handwritten digits
@@ -126,14 +126,14 @@ end
         """,
         "http://yann.lecun.com/exdb/mnist/".*["train-images-idx3-ubyte.gz", "train-labels-idx1-ubyte.gz", "t10k-images-idx3-ubyte.gz", "t10k-labels-idx1-ubyte.gz"],
         "0bb1d5775d852fc5bb32c76ca15a7eb4e9a3b1514a2493f7edfcf49b639d7975"
-    )
+    ))
 read(datadep"MNIST"*"/train-labels-idx1-ubyte.gz")
     @test read(datadep"MNIST"*"/train-labels-idx1-ubyte.gz") == read(datadep"MNIST train"*"/train-labels-idx1-ubyte.gz")
 end
 
 
 @testset "UCI Banking" begin
-    RegisterDataDep(
+    register(DataDep(
         "UCI Banking",
         """
         Dataset: Bank Marketing Data Set
@@ -152,7 +152,7 @@ end
          (SHA.sha3_224, "01b53f5b69d0b169070219b4391c623d84ab17d4cea8c8895cbf951d")];
 
          post_fetch_method = file->run(`unzip $file`)
-    )
+    ))
 
     data, header = readdlm(datadep"UCI Banking/bank.csv", ';', header=true)
     @test size(header) == (1,17)
@@ -168,7 +168,7 @@ end
     # Doing this with checksums is not particularly useful
     # But the same thing applies to `fetch_method` and `post_fetch_method`.
     # So for example the
-    RegisterDataDep(
+    register(DataDep(
         "UCI Adult",
         """
     	Dataset: Adult Data Set UCI ML Repository
@@ -199,7 +199,7 @@ end
              "818481d320861c4b623626ff6fab3426ad93dae4434b7f54ca5a0f357169c362" # adult.names ⊻ old.adult.names
             ]
         ]
-    )
+    ))
 
     @test length(collect(eachline(datadep"UCI Adult/adult.names"))) == 110
 
@@ -208,7 +208,7 @@ end
 
 
 @testset "Data.Gov Babynames" begin
-    RegisterDataDep(
+    register(DataDep(
         "Baby Names",
         """
         Dataset: Baby Names from Social Security Card Applications-National Level Data
@@ -226,7 +226,7 @@ end
         #TODO : Automate this test with new 0.7 test_warn stuff
         ;
         post_fetch_method = [unpack, f->mv(f, "metadata551randstuff.json")]
-    )
+    ))
 
     @test !any(endswith.(readdir(datadep"Baby Names"), "zip"))
     @test first(eachline(joinpath(datadep"Baby Names", "yob2016.txt")))=="Emma,F,19414"

--- a/test/examples_manual.jl
+++ b/test/examples_manual.jl
@@ -3,7 +3,7 @@ using Base.Test
 
 
 @testset "Manual included" begin
-    RegisterDataDep(
+    register(ManualDataDep(
         "Example",
         """
         This manual datadep should have been installed with the package.
@@ -11,7 +11,7 @@ using Base.Test
         Try removing and then adding the package back again.
         If that doesn't work raise an issue on the repo.
         """
-    )
+    ))
 
     content = readstring(datadep"Example"*"/loremipsum.txt")
     @test startswith(content, "lorem ipsum dolor sit amet")
@@ -20,7 +20,7 @@ end
 
 if DataDeps.env_bool("DATADEPS_ENABLE_MANUAL_TESTS")
     @testset "Manual nonincluded" begin
-        RegisterDataDep(
+        register(ManualDataDep(
             "Kafta",
             """
             Please go to
@@ -29,7 +29,7 @@ if DataDeps.env_bool("DATADEPS_ENABLE_MANUAL_TESTS")
                 Note this must be done manually as Project Gutenberg does not allow directly linking to their ebooks.
                 only to the canonical catalog entry (See https://www.gutenberg.org/wiki/Gutenberg:Information_About_Linking_to_our_Pages)
             """
-        )
+        ))
 
         @test first(readlines(datadep"Kafta"*"/mm.txt")) == "\ufeffThe Project Gutenberg EBook of Metamorphosis, by Franz Kafka"
     end

--- a/test/main.jl
+++ b/test/main.jl
@@ -13,12 +13,12 @@ withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
         @stub dummydown
         @expect(dummydown("http://www.example.com/eg.zip", ::String) = "eg.zip")
 
-        RegisterDataDep( "Test1",
+        register(DataDep( "Test1",
          "A dummy message",
          "http://www.example.com/eg.zip", # the remote-path to fetch it from, normally an URL. Passed to the `fetch_method`
          (dummyhash, "1234"), #A hash that is used to check the data is right.
          fetch_method=dummydown
-        )
+        ))
 
         @test endswith(datadep"Test1", "Test1") || endswith(datadep"Test1", "Test1/") ||  endswith(datadep"Test1", "Test1\\")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,30 +14,36 @@ for filename in tests
 end
 
 
+examples =  [
+    "examples.jl",
+    "examples_manual.jl",
+    "deprecated_examples.jl",
+    "deprecated_examples_manual.jl",
+]
 
-@testset "examples" begin
-    tempdir = mktempdir()
-    try
-        info("sending all datadeps to $tempdir")
-        withenv("DATADEPS_LOAD_PATH"=>tempdir) do
-            @testset "download and use" begin
-                include("examples.jl")
-                include("examples_manual.jl")
-            end
-            withenv("DATADEPS_DISABLE_DOWNLOAD"=>"true") do
-                @testset "use already downloaded" begin
-                    include("examples.jl")
-                    include("examples_manual.jl")
+@testset "examples" for fn in examples
+    @testset "$fn" begin
+        tempdir = mktempdir()
+        try
+            info("sending all datadeps to $tempdir")
+            withenv("DATADEPS_LOAD_PATH"=>tempdir) do
+                @testset "download and use" begin
+                    include(fn)
+                end
+                withenv("DATADEPS_DISABLE_DOWNLOAD"=>"true") do
+                    @testset "use already downloaded" begin
+                        include(fn)
+                    end
                 end
             end
+        finally
+    		try
+    			info("removing $tempdir")
+    			rm(tempdir, recursive=true, force=true)
+    		catch err
+    			warn("Something went wrong with removing $tempdir")
+    			warn(err)
+    		end
         end
-    finally
-		try
-			info("removing $tempdir")
-			rm(tempdir, recursive=true, force=true)
-		catch err
-			warn("Something went wrong with removing $tempdir")
-			warn(err)
-		end
     end
 end


### PR DESCRIPTION
This solves this issue pointed out in https://github.com/oxinabox/DataDeps.jl/issues/37

Along the way it also exposes `resolve`,
which I think might be nice for https://github.com/oxinabox/DataDeps.jl/issues/8
But I'm not yet convinced.
Having access to `resolve` does mean one can throw strings around as much as one likes, without getting hit by a dependency actually resolving until you call `resolve(namepath, @__FILE__)`
but nicer might just be to make interpolation work for `datadep""$namepath"? Or just live with `@datadep_str namepath`.