### PR TITLE
make gzip work right

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -13,7 +13,7 @@ if is_unix() && Sys.KERNEL != :FreeBSD
         elseif extension == ".zip"
             return (`unzip -x $file -d $directory`)
         elseif extension == ".gz"
-            return pipeline(`mkdir $directory`, `cp $file $directory`, `gzip -d $directory/$file`)
+            return pipeline(`gzip -k -d $directory/$file`)
         end
         error("I don't know how to unpack $file")
     end


### PR DESCRIPTION
There appears to be a flaw in gzip unpacking.
This code came from BinDeps.jl
Either our basic usage is different to in BinDeps.jl,
or it is there as well, and no one noticed, because distributing a gzipped non-tarball is rare