### PR TITLE
make so by default DATADEPS_LOAD_PATH preprends to default_loadpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,8 +345,9 @@ DataDeps.jl tries to have very sensible defaults.
     - This is provided for scripting (in particular CI) use
     - Note that it remains your responsibility to understand and read any terms of the data use (this is remains true even if you don't turn on this bypass)
 	- default `false`
- - `DATADEPS_LOAD_PATH` -- The list of paths, other than the package directory (`Pkg.dir(PKGNAME)/deps/data`) to save and load data from
-    - default values is complex. On all systems it includes the equivalent of `~/.julia/datadeps`. It also includes a large number of other locations such as `/usr/share/datadeps` on linux, and `C:/ProgramData` on Windows. [more details](#The-LOAD-PATH)
+ - `DATADEPS_LOAD_PATH` -- The list of paths to be prepended to the standard loadpath (and the package directory (`Pkg.dir(PKGNAME)/deps/data`)) to save and load data from
+    - By default this adds nothing to the setnaded set of values, which on all systems it includes the equivalent of `~/.julia/datadeps`. It also includes a large number of other locations such as `/usr/share/datadeps` on linux, and `C:/ProgramData` on Windows. [more details](#The-LOAD-PATH)
+ - `DATADEPS_NO_STANDARD_LOAD_PATH` if this is set to `true` (default `false`), then the aforementioned list of standard loadpath files is not included
  - `DATADEPS_DISABLE_DOWNLOAD` -- causes any action that would result in the download being triggered to throw an exception.
    - useful e.g. if you are in an environment with metered data, where your datasets should have already been downloaded earlier, and if there were not you want to respond to the situation rather than let DataDeps download them for you.
    - default `false`

--- a/src/locations.jl
+++ b/src/locations.jl
@@ -17,7 +17,7 @@ const default_loadpath = joinpath.([
          "/usr/share", "/usr/local/share"] # Unix Filestructure
     end], "datadeps")
 
-#ensure at least something in the loadpath exists.
+#ensure at least something in the loadpath exists when instaleld
 mkpath(first(default_loadpath))
 
 
@@ -97,7 +97,11 @@ function preferred_paths(rel=nothing; use_package_dir=true)
         pkg_deps_root = try_determine_package_datadeps_dir(rel)
         !isnull(pkg_deps_root) && push!(cands, get(pkg_deps_root))
     end
-    append!(cands, env_list("DATADEPS_LOAD_PATH", default_loadpath))
+
+    append!(cands, env_list("DATADEPS_LOAD_PATH", []))
+    if !env_bool("DATADEPS_EXCLUDE_DEFAULT_LOAD_PATH", true)
+        append!(cands, default_loadpath)
+    end
     cands
 end
 

--- a/src/locations.jl
+++ b/src/locations.jl
@@ -3,7 +3,7 @@
 ## Core path determining stuff
 
 
-const default_loadpath = joinpath.([
+const standard_loadpath = joinpath.([
     Pkg.Dir._pkgroot(); homedir(); # Common all systems
 
     @static if is_windows()
@@ -18,7 +18,7 @@ const default_loadpath = joinpath.([
     end], "datadeps")
 
 #ensure at least something in the loadpath exists when instaleld
-mkpath(first(default_loadpath))
+mkpath(first(standard_loadpath))
 
 
 
@@ -99,8 +99,8 @@ function preferred_paths(rel=nothing; use_package_dir=true)
     end
 
     append!(cands, env_list("DATADEPS_LOAD_PATH", []))
-    if !env_bool("DATADEPS_EXCLUDE_DEFAULT_LOAD_PATH", true)
-        append!(cands, default_loadpath)
+    if !env_bool("DATADEPS_NO_STANDARD_LOAD_PATH", false)
+        append!(cands, standard_loadpath)
     end
     cands
 end


### PR DESCRIPTION
Having now encountered a senario where I did want to chagne my DATADEPS_LOADPATH,
I can confirm what I suspected for a while: by default I just wanted to add new things to the start of the default list.

This PR makes that change,
and added an enviroment variable `DATADEPS_EXCLUDE_DEFAULT_LOAD_PATH` which if true causes the default path not to be included