### PR TITLE
use specific errors

### DIFF
--- a/src/DataDeps.jl
+++ b/src/DataDeps.jl
@@ -9,7 +9,7 @@ export DataDep, ManualDataDep
 export register, resolve, @datadep_str
 export unpack
 
-
+include("errors.jl")
 include("types.jl")
 
 include("util.jl")

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -1,0 +1,25 @@
+
+"""
+For when there is no valid location available to save to.
+"""
+struct NoValidPathError <: Exception
+    msg::String
+end
+
+"""
+For when a users has selected to abourt
+"""
+struct UserAbortError <: Exception
+    msg::String
+end
+abort(msg) = throw(UserAbortError(msg))
+
+
+"""
+DisabledError
+For when functionality that is disabled is attempted to be used
+"""
+struct DisabledError <: Exception
+    msg::String
+end
+

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -16,7 +16,7 @@ if is_unix() && Sys.KERNEL != :FreeBSD
             target = joinpath(directory, file)
             return pipeline(`gzip -k -d $target`)
         end
-        error("I don't know how to unpack $file")
+        throw(ArguementError("I don't know how to unpack $file"))
     end
 end
 
@@ -43,10 +43,8 @@ if is_windows()
         elseif (extension == ".zip" || extension== ".gz" || extension == ".7z" || extension == ".tar" ||
                 (extension == ".exe" && secondary_extension == ".7z"))
             return (`$exe7z x $file -y -o$directory`)
-        
-        
         end
-        error("I don't know how to unpack $file")
+        throw(ArguementError("I don't know how to unpack $file"))
     end
 end
 

--- a/src/locations.jl
+++ b/src/locations.jl
@@ -1,5 +1,4 @@
 # This file is a part of DataDeps.jl. License is MIT.
-
 ## Core path determining stuff
 
 
@@ -147,7 +146,7 @@ function determine_save_path(name, rel=nothing)::String
         0 == first(uv_access(path, W_OK))
     end
     if path_ind==0
-        error("No possible save path")
+        throw(NoValidPathError("No possible save path"))
     end
     return joinpath(cands[path_ind], name)
 end

--- a/src/registration.jl
+++ b/src/registration.jl
@@ -8,7 +8,7 @@ function register(datadep::AbstractDataDep)
         warn("Over-writing registration of the datadep: $name")
     end
     if !is_valid_name(name)
-        error(name, " is not a valid name for a datadep. Valid names must be legal foldernames on Windows.")
+        throw(ArgumentError(name, " is not a valid name for a datadep. Valid names must be legal foldernames on Windows."))
     end
 
     registry[name] = datadep

--- a/src/resolution.jl
+++ b/src/resolution.jl
@@ -38,7 +38,7 @@ function resolve(datadep::AbstractDataDep, inner_filepath, calling_filepath)::St
             warn("Something has gone wrong. What would you like to do?")
             input_choice(
                 ('A', "Abort -- this will error out",
-                    ()->error("Aborted resolving data dependency, program could not continue.")),
+                    ()->abort("Aborted resolving data dependency, program could not continue.")),
                 ('R', "Retry -- do this after fixing the problem outside of this script",
                     ()->nothing), # nothing to do
                 ('X', "Remove directory and retry  -- will retrigger download if there isn't another copy elsewhere",

--- a/src/resolution_automatic.jl
+++ b/src/resolution_automatic.jl
@@ -2,7 +2,9 @@
 
 function handle_missing(datadep::DataDep, calling_filepath)::String
     save_dir = determine_save_path(datadep.name, calling_filepath)
-    !env_bool("DATADEPS_DISABLE_DOWNLOAD") || error("DATADEPS_DISABLE_DOWNLOAD enviroment variable set. Can not trigger download.")
+    if env_bool("DATADEPS_DISABLE_DOWNLOAD")
+        throw(DisabledError("DATADEPS_DISABLE_DOWNLOAD enviroment variable set. Can not trigger download."))
+    end
     download(datadep, save_dir)
     save_dir
 end
@@ -113,7 +115,7 @@ function checksum_pass(hash, fetched_path)
         warn("Hash failed on $(fetched_path)")
         reply = input_choice("Do you wish to Abort, Retry download or Ignore", 'a','r','i')
         if reply=='a'
-            error("Hash Failed")
+            abort("Hash Failed, user elected not to retry")
         elseif reply=='r'
             return false
         end
@@ -139,7 +141,7 @@ function accept_terms(datadep::DataDep, localpath, remotepath, ::Void)
 end
 function accept_terms(datadep::DataDep, localpath, remotepath, i_accept_the_terms_of_use::Bool)
     if !i_accept_the_terms_of_use
-        error("User declined to download $(datadep.name). Can not proceed without the data.")
+        abort("User declined to download $(datadep.name). Can not proceed without the data.")
     end
     true
 end

--- a/src/resolution_manual.jl
+++ b/src/resolution_manual.jl
@@ -13,7 +13,7 @@ function handle_missing(datadep::ManualDataDep, calling_filepath)::String
     while true
         reply = input_choice("Once installed please enter 'y' reattempt loading, or 'a' to abort", 'y','a')
         if reply=='a'
-            error("User has aborted attempt to load datadep. Can not proceed without loading.")
+            abort("User has aborted attempt to load datadep. Can not proceed without loading.")
         end
         lp = try_determine_load_path(datadep.name, calling_filepath)
         if isnull(lp)


### PR DESCRIPTION
This removes all uses of `error` with something catch-able.

Thus practicing what I preach in https://discourse.julialang.org/t/please-stop-using-error-and-errorexception-in-packages-and-base/12096/18