### PR TITLE
fix inconsistencies with DATADEPS_ALWAYS_ACCEPT env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The short version is:
 1. Stick your data anywhere with a open HTTP link. (Skip this if it is already online.)
 2. Write a DataDep registration block.
 3. Refer to the data using `datadep"Dataname/file.csv` etc as if it were a file path, and DataDeps.jl will sort out getting in onto your system.
-4. For CI purposes set the `DATADEPS_ALWAY_ACCEPT` environment variable.
+4. For CI purposes set the `DATADEPS_ALWAYS_ACCEPT` environment variable.
 
 #### Where can I store my data online?
 Where ever you want, so long as it gives an Open HTTP(/s) link to download it. ** 
@@ -381,7 +381,7 @@ You can set these in the `.juliarc` file using the `ENV` dictionary if you don't
 However, most people shouldn't need to.
 DataDeps.jl tries to have very sensible defaults.
 
- - `DATADEPS_ALWAY_ACCEPT` -- bypasses the confirmation before downloading data. Set to `true` (or similar string)
+ - `DATADEPS_ALWAYS_ACCEPT` -- bypasses the confirmation before downloading data. Set to `true` (or similar string)
     - This is provided for scripting (in particular CI) use
     - Note that it remains your responsibility to understand and read any terms of the data use (this is remains true even if you don't turn on this bypass)
 	- default `false`

--- a/src/resolution_automatic.jl
+++ b/src/resolution_automatic.jl
@@ -129,7 +129,11 @@ end
 Ensurses the user accepts the terms of use; otherwise errors out.
 """
 function accept_terms(datadep::DataDep, localpath, remotepath, ::Nothing)
-    if !env_bool("DATADEPS_ALWAY_ACCEPT")
+   if haskey(ENV, "DATADEPS_ALWAY_ACCEPT")
+       warn("Environment variable \$DATADEPS_ALWAY_ACCEPT is deprecated. " *
+            "Please use \$DATADEPS_ALWAYS_ACCEPT instead.")
+   end
+    if !(env_bool("DATADEPS_ALWAYS_ACCEPT") || env_bool("DATADEPS_ALWAY_ACCEPT"))
         response = check_if_accept_terms(datadep, localpath, remotepath)
         accept_terms(datadep, localpath, remotepath, response)
     else

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -2,7 +2,7 @@ using Test
 using DataDeps
 using DelimitedFiles
 
-ENV["DATADEPS_ALWAY_ACCEPT"]=true
+ENV["DATADEPS_ALWAYS_ACCEPT"]=true
 
 @testset "Pi" begin
     register(DataDep(

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -2,7 +2,7 @@ using Test
 using DataDeps
 using DelimitedFiles
 
-ENV["DATADEPS_ALWAYS_ACCEPT"]=true
+ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 
 @testset "Pi" begin
     register(DataDep(

--- a/test/main.jl
+++ b/test/main.jl
@@ -6,7 +6,7 @@ using ExpectationStubs
 # HACK: todo, work out how ExpectationStubs should be changed to make this make sense
 Base.open(stub::Stub, t::Any, ::AbstractString) = stub(t)
 
-withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
+withenv("DATADEPS_ALWAYS_ACCEPT"=>"true") do
     @testset "automatic download" begin
         @stub dummyhash
         @expect(dummyhash(::Any) = [0x12, 0x34])


### PR DESCRIPTION
I noticed that in the code and documentation for DataDeps, sometimes it refers to an environment variable "DATADEPS_ALWAYS_ACCEPT" and sometimes to "DATADEPS_ALWAY_ACCEPT." I figured that the "ALWAY_" one was probably a typo, so this pull request fixes those cases.