### PR TITLE
Avoid broadcasting error on 1.0 with Windows

### DIFF
--- a/src/locations.jl
+++ b/src/locations.jl
@@ -5,7 +5,7 @@ const standard_loadpath = joinpath.([
     Base.DEPOT_PATH; homedir(); # Common all systems
 
     @static if Sys.iswindows()
-        vcat(get.(ENV,
+        vcat(get.(Ref(ENV),
            ["APPDATA", "LOCALAPPDATA",
             "ProgramData", "ALLUSERSPROFILE", # Probably the same, on all systems where both exist
             "PUBLIC", "USERPROFILE"], # Home Dirs ("USERPROFILE" is probably the same as homedir()


### PR DESCRIPTION
On Windows the following error shows up when the package is loaded. Not sure if this is how you want to fix it, but it should do the trick

```
ERROR: LoadError: LoadError: ArgumentError: broadcasting over dictionaries and `NamedTuple`s is reserved
Stacktrace:
 [1] broadcastable(::Base.EnvDict) at .\broadcast.jl:610
 [2] broadcasted(::Function, ::Base.EnvDict, ::Array{String,1}, ::Array{Array{String,1},1}) at .\broadcast.jl:1163
 [3] top-level scope at C:\Users\appveyor\.julia\packages\DataDeps\a8xNH\src\locations.jl:8
 [4] include at .\sysimg.jl:29 [inlined]
 [5] include(::String) at C:\Users\appveyor\.julia\packages\DataDeps\a8xNH\src\DataDeps.jl:2
 [6] top-level scope at none:0
 [7] include at .\boot.jl:317 [inlined]
 [8] include_relative(::Module, ::String) at .\loading.jl:1041
 [9] include(::Module, ::String) at .\sysimg.jl:29
 [10] top-level scope at none:2
 [11] eval at .\boot.jl:319 [inlined]
 [12] eval(::Expr) at .\client.jl:389
 [13] top-level scope at .\none:3
in expression starting at C:\Users\appveyor\.julia\packages\DataDeps\a8xNH\src\locations.jl:4
in expression starting at C:\Users\appveyor\.julia\packages\DataDeps\a8xNH\src\DataDeps.jl:19
```