### PR TITLE
Update Project.toml to allow for newer HTTP.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
 ExpectationStubs = "0.2"
-HTTP = "0.8.5"
+HTTP = "~0.8.5"
 Reexport = "0.2"
 julia = "1"
 


### PR DESCRIPTION
HTTP.jl has been releasing newer versions, but is bound to 0.8.5 by DataDeps.jl therefore holding dependent packages back.
In particular I need v0.8.12 since that supports MbedTLS.jl 1.0