### PR TITLE
remove shelling out from example

### DIFF
--- a/docs/src/z20-for-pkg-devs.md
+++ b/docs/src/z20-for-pkg-devs.md
@@ -159,7 +159,7 @@ For example:
 ```
 register(DataDep("eg", "eg message",
     ["http//example.com/text.txt", "http//example.com/sub1.zip", "http//example.com/sub2.zip"]
-    post_fetch_method = [identity, file->run(`unzip $file`), file->run(`unzip $file`)]
+    post_fetch_method = [identity, unpack, unpack]
 ))
 ```
 So `identity`  (i.e. nothing) will be done to the first paths resulting file, and the second and third will be unzipped.
@@ -168,7 +168,7 @@ can also be written:
 ```
 register(DataDep("eg", "eg message",
     ["http//example.com/text.txt", ["http//example.com/sub1.zip", "http//example.com/sub2.zip"]]
-    post_fetch_method = [identity, file->run(`unzip $file`)]
+    post_fetch_method = [identity, unpack]
 ))
 ```
 The unzip will be applied to both elements in the child array
@@ -199,7 +199,7 @@ The hierachy of methods for acquiring a datadep is:
 `datadep"name/path"` ▶ `resolve("name/path", @__FILE__)` ▶ `resolve(::AbstractDataDep, "name", @__FILE__)` ▶ `download(::DataDep)`
 
 One can make use of this at various levels to override the default generally sane behavior.
-Most of the time you shouldn't have to -- the normal point of customization is in setting the `post_fetch_method`, and occasionally `fetch_method` or  `hash=(hashmethod, key)`.
+Most of the time you shouldn't have to -- the normal point of customization is in setting the `post_fetch_method`, and occasionally `fetch_method` or `hash=(hashmethod, key)`.
 
 
 ## `download` for low-level programmatic resolution.


### PR DESCRIPTION
Examples were using shelling out to `unzip` rather than `unpack` which seems likely to confuse people into thinking shelling out is a good idea.
`unpack` is a much better way to do this.

thanks @jlperla for spotting this