### PR TITLE
Use p7zip in unpack_cmd

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.7.3"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [compat]
 ExpectationStubs = "0.2"

--- a/src/DataDeps.jl
+++ b/src/DataDeps.jl
@@ -2,6 +2,7 @@
 module DataDeps
 
 using HTTP
+using p7zip_jll
 using Reexport
 @reexport using SHA
 

--- a/src/post_fetch_helpers.jl
+++ b/src/post_fetch_helpers.jl
@@ -1,16 +1,5 @@
 # This file is a part of DataDeps.jl. License is MIT.
 
-function unpack_cmd(file,directory,extension,secondary_extension)
-    output_dir = first(splitext(file))
-    p7zip() do p7zip_executable_path
-        try
-            run(`$p7zip_executable_path e $file -o$output_dir`)
-        catch err
-            throw(ArgumentError("failed to extract specified file. Please check if the path is correct, if yes, either the file has an unsupported extension or corrupt."))
-        end
-    end
-end
-
 """
     unpack(f; keep_originals=false)
 
@@ -18,7 +7,16 @@ Extracts the content of an archive in the current directory;
 deleting the original archive, unless the `keep_originals` flag is set.
 """
 function unpack(f; keep_originals=false)
-    unpack_cmd(f, pwd(), last(splitext(f)), last(splitext(first(splitext(f)))))
+    file,directory,extension,secondary_extension = f, first(splitext(f)), last(splitext(f)), last(splitext(first(splitext(f))))
+
+    p7zip() do p7zip_executable_path
+        try
+            run(`$p7zip_executable_path e $file -o$directory`)
+        catch err
+            throw(ArgumentError("failed to extract specified file. Please check if the path is correct, if yes, either the file has an unsupported extension or corrupt."))
+        end
+    end
+
     rm("pax_global_header"; force=true)# Non-compliant tarball extractors dump out this file. It is meaningly (google it's filename for more)
     !keep_originals && rm(f)
 end

--- a/src/post_fetch_helpers.jl
+++ b/src/post_fetch_helpers.jl
@@ -1,5 +1,3 @@
-using p7zip_jll
-
 function unpack_cmd(file,directory,extension,secondary_extension)
     if ((extension == ".Z" || extension == ".gz" || extension == ".xz" || extension == ".bz2") && secondary_extension == ".tar") || extension == ".tgz" || extension == ".tbz" || extension == ".zip" || extension== ".gz" || extension == ".7z" || extension == ".tar" || (extension == ".exe" && secondary_extension == ".7z")
         output_dir = first(splitext(file))

--- a/src/post_fetch_helpers.jl
+++ b/src/post_fetch_helpers.jl
@@ -12,14 +12,15 @@ function unpack(f; keep_originals=false)
     p7zip() do p7zip_executable_path
         try
             if secondary_extension == ""
-                run(`$p7zip_executable_path e $file -o$directory`)
+                run(`$p7zip_executable_path e $file -o$directory -y`)
             else
-                intermediate_file = directory
+                intermediate_dir, intermediate_file = first(splitdir(file)), directory
                 directory = first(splitext(intermediate_file))
+
                 # 7z x creates intermediate compressed file
-                run(`$p7zip_executable_path x $file`)
+                run(`$p7zip_executable_path x $file -o$intermediate_dir -y`)
                 # 7z e extracts the intermediate file and places content in a directory
-                run(`$p7zip_executable_path e $intermediate_file -o$directory`)
+                run(`$p7zip_executable_path e $intermediate_file -o$directory -y`)
                 # once this process is successful intermediate file is deleted
                 rm(intermediate_file)
             end

--- a/src/post_fetch_helpers.jl
+++ b/src/post_fetch_helpers.jl
@@ -1,57 +1,15 @@
-# This file is a part of DataDeps.jl. License is MIT.
+using p7zip_jll
 
-if Sys.isunix() && Sys.KERNEL != :FreeBSD
-    function unpack_cmd(file,directory,extension,secondary_extension)
-        if ((extension == ".gz" || extension == ".Z") && secondary_extension == ".tar") || extension == ".tgz"
-            return (`tar xzf $file --directory=$directory`)
-        elseif (extension == ".bz2" && secondary_extension == ".tar") || extension == ".tbz"
-            return (`tar xjf $file --directory=$directory`)
-        elseif extension == ".xz" && secondary_extension == ".tar"
-            return pipeline(`unxz -c $file `, `tar xv --directory=$directory`)
-        elseif extension == ".tar"
-            return (`tar xf $file --directory=$directory`)
-        elseif extension == ".zip"
-            return (`unzip -x $file -d $directory`)
-        elseif extension == ".gz"
-            target = joinpath(directory, file)
-            return pipeline(`gzip -k -d $target`)
+function unpack_cmd(file,directory,extension,secondary_extension)
+    if ((extension == ".Z" || extension == ".gz" || extension == ".xz" || extension == ".bz2") && secondary_extension == ".tar") || extension == ".tgz" || extension == ".tbz" || extension == ".zip" || extension== ".gz" || extension == ".7z" || extension == ".tar" || (extension == ".exe" && secondary_extension == ".7z")
+        output_dir = first(splitext(file))
+        p7zip() do p7zip_executable_path
+            run(`$p7zip_executable_path e $file -o$output_dir`)
         end
-        throw(ArgumentError("I don't know how to unpack $file"))
-    end
-end
-
-if Sys.KERNEL == :FreeBSD
-    # The `tar` on FreeBSD can auto-detect the archive format via libarchive.
-    # The supported formats can be found in libarchive-formats(5).
-    # For NetBSD and OpenBSD, libarchive is not available.
-    # For macOS, it is. But the previous unpack function works fine already.
-    function unpack_cmd(file, dir, ext, secondary_ext)
-        tar_args = ["--no-same-owner", "--no-same-permissions"]
-        return pipeline(
-            `/bin/mkdir -p $dir`,
-            `/usr/bin/tar -xf $file -C $dir $tar_args`)
-    end
-end
-
-if Sys.iswindows()
-    if isdefined(Base, :LIBEXECDIR)
-        const exe7z = joinpath(Sys.BINDIR, Base.LIBEXECDIR, "7z.exe")
     else
-        const exe7z = joinpath(Sys.BINDIR, "7z.exe")
-    end
-
-    function unpack_cmd(file,directory,extension,secondary_extension)
-        if ((extension == ".Z" || extension == ".gz" || extension == ".xz" || extension == ".bz2") &&
-                secondary_extension == ".tar") || extension == ".tgz" || extension == ".tbz"
-            return pipeline(`$exe7z x $file -y -so`, `$exe7z x -si -y -ttar -o$directory`)
-        elseif (extension == ".zip" || extension== ".gz" || extension == ".7z" || extension == ".tar" ||
-                (extension == ".exe" && secondary_extension == ".7z"))
-            return (`$exe7z x $file -y -o$directory`)
-        end
         throw(ArgumentError("I don't know how to unpack $file"))
     end
 end
-
 
 """
     unpack(f; keep_originals=false)
@@ -60,7 +18,7 @@ Extracts the content of an archive in the current directory;
 deleting the original archive, unless the `keep_originals` flag is set.
 """
 function unpack(f; keep_originals=false)
-    run(unpack_cmd(f, pwd(), last(splitext(f)), last(splitext(first(splitext(f))))))
+    unpack_cmd(f, pwd(), last(splitext(f)), last(splitext(first(splitext(f)))))
     rm("pax_global_header"; force=true)# Non-compliant tarball extractors dump out this file. It is meaningly (google it's filename for more)
     !keep_originals && rm(f)
 end

--- a/src/post_fetch_helpers.jl
+++ b/src/post_fetch_helpers.jl
@@ -1,11 +1,13 @@
+# This file is a part of DataDeps.jl. License is MIT.
+
 function unpack_cmd(file,directory,extension,secondary_extension)
-    if ((extension == ".Z" || extension == ".gz" || extension == ".xz" || extension == ".bz2") && secondary_extension == ".tar") || extension == ".tgz" || extension == ".tbz" || extension == ".zip" || extension== ".gz" || extension == ".7z" || extension == ".tar" || (extension == ".exe" && secondary_extension == ".7z")
-        output_dir = first(splitext(file))
-        p7zip() do p7zip_executable_path
+    output_dir = first(splitext(file))
+    p7zip() do p7zip_executable_path
+        try
             run(`$p7zip_executable_path e $file -o$output_dir`)
+        catch err
+            throw(ArgumentError("failed to extract specified file. Please check if the path is correct, if yes, either the file has an unsupported extension or corrupt."))
         end
-    else
-        throw(ArgumentError("I don't know how to unpack $file"))
     end
 end
 

--- a/src/post_fetch_helpers.jl
+++ b/src/post_fetch_helpers.jl
@@ -11,7 +11,18 @@ function unpack(f; keep_originals=false)
 
     p7zip() do p7zip_executable_path
         try
-            run(`$p7zip_executable_path e $file -o$directory`)
+            if secondary_extension == ""
+                run(`$p7zip_executable_path e $file -o$directory`)
+            else
+                intermediate_file = directory
+                directory = first(splitext(intermediate_file))
+                # 7z x creates intermediate compressed file
+                run(`$p7zip_executable_path x $file`)
+                # 7z e extracts the intermediate file and places content in a directory
+                run(`$p7zip_executable_path e $intermediate_file -o$directory`)
+                # once this process is successful intermediate file is deleted
+                rm(intermediate_file)
+            end
         catch err
             throw(ArgumentError("failed to extract specified file. Please check if the path is correct, if yes, either the file has an unsupported extension or corrupt."))
         end

--- a/src/post_fetch_helpers.jl
+++ b/src/post_fetch_helpers.jl
@@ -7,16 +7,26 @@ Extracts the content of an archive in the current directory;
 deleting the original archive, unless the `keep_originals` flag is set.
 """
 function unpack(f; keep_originals=false)
-    file,directory,extension,secondary_extension = f, first(splitext(f)), last(splitext(f)), last(splitext(first(splitext(f))))
-
+    file = f # /home/hello/xyz.zip  |   /home/hello/xyz.tar.gz
+    directory = first(splitext(f)) # /home/hello/xyz  |   /home/hello/xyz.tar
+    extension = last(splitext(f)) # .zip    |   .gz
+    secondary_extension = last(splitext(first(splitext(f)))) #  ""  |   .tar
+    # p7zip() returns the path of 7z exectuable
     p7zip() do p7zip_executable_path
         try
             if secondary_extension == ""
+                # for files with a single compression like .zip, .rar, etc.
                 run(`$p7zip_executable_path e $file -o$directory -y`)
             else
+                # files with secondary extension like .tar.gz, 
+                # first extract .tar.gz to .tar in the directory where .tar.gz was present
+                # this .tar is the intermediate file 
+                # splitext("/home/filename.tar.gz") returns "/home/filename.tar" which is filename of our intermediate file
                 intermediate_dir, intermediate_file = first(splitdir(file)), directory
+                # directory in which data is to be extracted is split again
+                # "/home/filename.tar" is converted to "/home/filename"
                 directory = first(splitext(intermediate_file))
-
+                # check out 7z docs for more information
                 # 7z x creates intermediate compressed file
                 run(`$p7zip_executable_path x $file -o$intermediate_dir -y`)
                 # 7z e extracts the intermediate file and places content in a directory
@@ -25,10 +35,9 @@ function unpack(f; keep_originals=false)
                 rm(intermediate_file)
             end
         catch err
-            throw(ArgumentError("failed to extract specified file. Please check if the path is correct, if yes, either the file has an unsupported extension or corrupt."))
+            @warn "failed to extract specified file. Please check if the path is correct, if yes, either the file has an unsupported extension or corrupt."
+            rethrow(err)
         end
     end
-
-    rm("pax_global_header"; force=true)# Non-compliant tarball extractors dump out this file. It is meaningly (google it's filename for more)
     !keep_originals && rm(f)
 end


### PR DESCRIPTION
closes #116 

Work in progress.

- [x] Use p7zip to extract compressed files
- [x] Handle tar.gz files separately
- [ ] Support earlier Julia versions using BinaryProvider.jl