### PR TITLE
Always fallback to 7zip even if don't know it will work

### DIFF
--- a/src/post_fetch_helpers.jl
+++ b/src/post_fetch_helpers.jl
@@ -2,14 +2,12 @@
 
 function unpack_cmd(file,directory,extension,secondary_extension)
     p7zip() do exe7z
-        if ((extension == ".Z" || extension == ".gz" || extension == ".xz" || extension == ".bz2") &&
-                secondary_extension == ".tar") || extension == ".tgz" || extension == ".tbz"
+        if secondary_extension == ".tar" || extension == ".tgz" || extension == ".tbz"
+            # special handling for compressed tarballs
             return pipeline(`$exe7z x $file -y -so`, `$exe7z x -si -y -ttar -o$directory`)
-        elseif (extension == ".zip" || extension== ".gz" || extension == ".7z" || extension == ".tar" ||
-                (extension == ".exe" && secondary_extension == ".7z"))
+        else
             return `$exe7z x $file -y -o$directory`
         end
-        throw(ArgumentError("Unsupported archive extension: $file"))
     end
 end
 


### PR DESCRIPTION
Follow up to #116 / #127 / #123 
closes #106  (tested locally as i don't know of any `xz` files online that can be used for testing and don't particularly want to bloat the repo with sample files, though perhaps I should.)

Basically 7zip is the  most comprehensive compression tool around, if it can't decompress it then odds are nothing can.
This changes the logic around so that we never fallback to throwing an error for an unrecognized type.
We just try to use 7zip, and if that works then good. and if it doesn't then it will throw an error.

