### PR TITLE
RFC: DataSets.jl intergration

### DIFF
--- a/Data.toml
+++ b/Data.toml
@@ -1,0 +1,11 @@
+data_config_version=1
+
+[[datasets]]
+name="Pi"
+uuid="76e82d27-3914-4472-abb6-38d476023211"
+
+    [datasets.storage]
+    driver="DataDeps"
+    sha256="1f08958df70c30bbf3f7205ad5f9b2b9430e3378b4e4e6300063bd9fbd83d6e3"
+    localdir="~/.julia/datadeps/Pi"
+    remote_path=["https://www.angio.net/pi/digits/10000.txt"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.7.7"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+DataSets = "c9661210-8a83-48f0-b833-72e62abce419"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/src/DataDeps.jl
+++ b/src/DataDeps.jl
@@ -42,4 +42,12 @@ include("preupload.jl")
 include("fetch_helpers.jl")
 include("post_fetch_helpers.jl")
 
+# Extension
+using DataSets
+include("datasets_storage_driver.jl")
+
+function __init__()
+    DataSets.add_storage_driver("DataDeps"=>DataDep_storage_driver)
+end
+
 end # module

--- a/src/datasets_storage_driver.jl
+++ b/src/datasets_storage_driver.jl
@@ -1,0 +1,21 @@
+# storage driver for DataSets.jl
+
+function DataDep_storage_driver(user_func, storage_config, dataset)
+    conf = dataset.conf
+    dp = DataDep(
+        conf["name"],
+        "",
+        storage_config["remote_path"],
+        get(storage_config, "sha256", "")
+    )
+    localdir = expanduser(storage_config["localdir"])
+    if !isdir(localdir)
+        try
+            DataDeps.download(dp, localdir; i_accept_the_terms_of_use=true)
+        catch
+            @error "failed to download dataset"
+            rm(localdir; recursive=true)
+        end
+    end
+    user_func(BlobTree(DataSets.FileSystemRoot(localdir), path"."))
+end


### PR DESCRIPTION
DataDeps is quite reliable to download the content, but it can sometimes be troublesome to manage a dataset registry if datasets information are hardcoded as Julia source code. I think DataSets.jl toml specification is quite promising to eventually provide a general registry for datasets, so maybe we can just integrate DataDeps into DataSets as a downloading driver.

This is just a proof of concept, I want to know your thoughts on this before I start polishing the details.

```julia
julia> using DataSets, DataDeps

julia> ds = dataset("Pi")
name = "Pi"
uuid = "76e82d27-3914-4472-abb6-38d476023211"

[storage]
driver = "DataDeps"
remote_path = ["https://www.angio.net/pi/digits/10000.txt"]
sha256 = "1f08958df70c30bbf3f7205ad5f9b2b9430e3378b4e4e6300063bd9fbd83d6e3"
localdir = "~/.julia/datadeps/Pi"


julia> ds_blobtree = open(ds)
┌ Info: Downloading
│   source = "https://www.angio.net/pi/digits/10000.txt"
│   dest = "/Users/jc/.julia/datadeps/Pi/10000.txt"
│   progress = NaN
│   time_taken = "0.0 s"
│   time_remaining = "NaN s"
│   average_speed = "1.908 MiB/s"
│   downloaded = "9.767 KiB"
│   remaining = "∞ B"
└   total = "∞ B"
📂 Tree . @ /Users/jc/.julia/datadeps/Pi
 📄 10000.txt

julia> read(ds_blobtree["10000.txt"], String)
"3.14159265358979
...
```

cc: @c42f