### PR TITLE
Update docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,7 +28,7 @@ Where ever you want, so long as it gives an Open HTTP(/s) link to download it. *
 **(In other protocols and auth can be supported by using a different `fetch_method`)
 
 
-#### Why not store the data in Git?
+### Why not store the data in Git?
 Git is good for files that meet 3 requirements:
 
  - Plain text (not binary)
@@ -49,7 +49,7 @@ It lives on some website somewhere.
 You don't want to copy and redistribute it;
 and depending on licensing you may not even be allowed to.
 
-#### But my data is dynamic
+### But my data is dynamic
 Well how dynamic?
 If you are willing to tag a new release of your package each time the data changes, then maybe this is no worry, but maybe it is.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,9 +17,9 @@ The short version is:
 4. For CI purposes set the `DATADEPS_ALWAYS_ACCEPT` environment variable.
 
 ### Where can I store my data online?
-Where ever you want, so long as it gives an Open HTTP(/s) link to download it. ** 
+Where ever you want, so long as it gives an Open HTTP(/s) link to download it. **
 
- - I use an OwnCloud instance hosted by our national research infastructure.
+ - I use an OwnCloud instance hosted by our national research infrastructure.
  - Research data hosting like FigShare are a good idea.
  - You can just stick it on your website hosting if you are operating a website.
  - I'd like to hear if anyone has tested GoogleDrive or DropBox etc.
@@ -47,11 +47,11 @@ The main use case is downloading large datasets for machine learning, and corpor
 In this case the data is not even normally yours to begin with.
 It lives on some website somewhere.
 You don't want to copy and redistribute it;
-and depending on liscensing you may not even be allowed to.
+and depending on licensing you may not even be allowed to.
 
 #### But my data is dynamic
 Well how dynamic?
-If you are willing to tag a new relase of your package each time the data changes, then maybe this is no worry, but maybe it is.
+If you are willing to tag a new release of your package each time the data changes, then maybe this is no worry, but maybe it is.
 
 But the real question is, is DataDeps.jl really suitable for managing your data properly in the first place.
 DataDeps.jl does not provide for versioning of data -- you can't force users to download new copies of your data using DataDeps.
@@ -78,11 +78,11 @@ Alternatives that I am aware of are:
 
  - [RemoteFiles.jl](https://github.com/helgee/RemoteFiles.jl): keeps local files up to date with remotes. In someways it is the opposite of DataDeps.jl (which means it is actually very similar in many ways).
  - [BinaryProvider.jl](https://github.com/JuliaPackaging/BinaryProvider.jl) downloads binaries intended as part of a build chain. I'm pretty sure you can trick it into downloading data.
- - [`Base.download`](https://docs.julialang.org/en/stable/stdlib/file/#Base.download) if your situtation is really simple just sticking a `download` into the `deps/build.jl` file might do you just fine.
+ - [`Base.download`](https://docs.julialang.org/en/stable/stdlib/file/#Base.download) if your situation is really simple just sticking a `download` into the `deps/build.jl` file might do you just fine.
 
  Outside of julia's ecosystem is
 
   - [Python: Quilt](https://github.com/quiltdata/quilt). Quilt uses a centralised data store, and allows the user to download the data as Python packages containing it in serialised from. It *might* be possible to use PyCall.jl to use this from julia.
   - [R: suppdata](https://github.com/ropensci/suppdata), features extra stuff relating to published datasets (See also DataDepsGenerators.jl), it *might* be possible to use RCall.jl to use this from julia.
   - [Node/Commandline: Datproject](https://datproject.org/) I'm not too familiar with this, it is a bit of an ecosystem of its own. I think using it from the commandline might satisfy many people's needs. Or automating it with shell calls in `build.jl`.
-  
+

--- a/docs/src/z10-for-end-users.md
+++ b/docs/src/z10-for-end-users.md
@@ -6,7 +6,7 @@ They should just forget about the data their package needs.
 Moving data is a great idea.
 DataDeps.jl is in favour of moving data.
 When data is automatically downloaded it will almost always go to the same location:
-the first (existant, writable) directory on your `DATADEPS_LOAD_PATH`.
+the first (existent, writable) directory on your `DATADEPS_LOAD_PATH`.
 Which by-default is `~/.julia/datadeps/`.
 (If you delete this, it will go to another location).
 But you can move them from there to anywhere in the `DATADEPS_LOAD_PATH`. (See below)
@@ -71,7 +71,7 @@ C:\Users\Public\datadeps
 
 ### Having multiple copies of the same DataDir
 You probably don't want to have multiple copies of a DataDir with the same name.
-DataDeps.jl will try to handle it as gracefuly as it can.
+DataDeps.jl will try to handle it as gracefully as it can.
 But having different `DataDep`s under the same name, is probably going to lead to packages loading the wrong one.
 Except if they are (both) located in their packages `deps/data` folder.
 
@@ -97,7 +97,7 @@ rm(datadep"MyDataName"; recursive=true)
 ```
 
 ## Configuration
-Currently configuration is done via Enviroment Variables.
+Currently configuration is done via Environment Variables.
 It is likely to stay that way, as they are also easy to setup in CI tools.
 You can set these in the [`startup.jl`](https://docs.julialang.org/en/v1/manual/getting-started/)
 file using the `ENV` dictionary if you don't want to mess up your `.profile`.
@@ -106,7 +106,7 @@ DataDeps.jl tries to have very sensible defaults.
 
  - `DATADEPS_ALWAYS_ACCEPT` -- bypasses the confirmation before downloading data. Set to `true` (or similar string)
     - default: `false`
-    - Note that it remains your responsibility to understand and read any terms of the data use (this is remains true even if you don't turn on this bypass)    
+    - Note that it remains your responsibility to understand and read any terms of the data use (this is remains true even if you don't turn on this bypass)
     - This is provided for scripting (in particular CI) use
     - If the `CI` environment variable is set to true, `DATADEPS_ALWAYS_ACCEPT`  **must be set** to true or false. This is to prevent hanging in CI.
  - `DATADEPS_PROGRESS_UPDATE_PERIOD` -- how often (in seconds) to print the progress to the log for the download

--- a/docs/src/z20-for-pkg-devs.md
+++ b/docs/src/z20-for-pkg-devs.md
@@ -43,7 +43,7 @@ Most packages using more than one data source, will want to download them only w
 That is to say if the user never calls a function that requires that data, then the data should not be downloaded.
 
 DataDeps.jl resolves the dependency when a `datadep"Name"` string is evaluated.
-If no code containing a data dependency string is run, then no data will be downloaded
+If no code containing a data dependency string is run, then no data will be downloaded.
 
 The basic way is to hide the datadep in some code not being evaluated except on a condition.
 For example, say some webcam security system can be run in training mode, in which case data should be used from the datadep,
@@ -65,14 +65,14 @@ So the data will not be sourced via DataDeps.jl
 If you want the data to be installed when the package is first loaded,
 just put the datadep string `datadep"Name"` anywhere it will immediately run.
 For example, in the `__init__` function immediately after the registration block.
-(Do not put it at global scope as otherwise it will run before `__init__` and thus error.
+(Do not put it at global scope as otherwise it will run before `__init__` and thus error).
 
 
-If you want it to be installed at `Pkg.build` time.
-This is theoretically possible, but not advised, using `deps/build.jl`.
+If you want it to be installed at `Pkg.build` time,
+this is theoretically possible, but not advised, do so using `deps/build.jl`.
 Note: that user IO is not possibly during `Pkg.build`, so the prompt to accept the download will not be shown.
 You thus must have `ENV["DATADEPS_ALWAYS_ACCEPT"]="true"` set, or it will fail.
-If you do do this, you will need to ensure the registration code is specified in the package as well, so that DataDeps.jl can local the files downloaded at build-time.
+If you do do this, you will need to ensure the registration code is specified in the package as well, so that DataDeps.jl can locate the files downloaded at build-time.
 
 
 
@@ -97,7 +97,7 @@ register(DataDep(
     name::String,
     message::String,
     remote_path::Union{String,Vector{String}...},
-    [checksum::Union{String,Vector{String}...},]; # Optional, if not provided will generate
+    [hash::Union{String,Vector{String}...},]; # Optional, if not provided will generate
     # keyword args (Optional):
     fetch_method=fetch_default # (remote_filepath, local_directory_path)->local_filepath
     post_fetch_method=identity # (local_filepath)->Any
@@ -106,44 +106,45 @@ register(DataDep(
 
 ### Required Fields
 
- - *Name**: the name used to refer to this datadep, coresponds to a folder name where it will be stored
+ - `name`: the name used to refer to this datadep
+    - Coresponds to a folder name where the datatep will be stored.
     - It can have spaces or any other character that is allowed in a Windows filestring (which is a strict subset of the restriction for unix filenames).
- - *Message*: A message displayed to the user for they are asked if they want to downloaded it.
+ - `message`: a message displayed to the user for they are asked if they want to download it
     - This is normally used to give a link to the original source of the data, a paper to be cited etc.
- - *remote_path*: where to fetch the data from. Normally a string or strings) containing an URL
-    - This is usually a string, or a vector of strings (or a vector of vector... see [Recursive Structure](@ref) below)
+ - `remote_path`: where to fetch the data from
+    - This is usually a string, or a vector of strings (or a vector of vectors... see [Recursive Structure](@ref) below).
 
 ### Optional Fields
- - *checksum* this is very flexible, it is used to check the files downloaded correctly
-    - By far the most common use is to just provide a SHA256 sum as a hex-string for the files
-    - If not provided, then a warning message with the  SHA256 sum is displayed. This is to help package devs workout the sum for there files, without using an external tool. You can also calculate it using [Preupload Checking](@ref).
-    - If you want to use a different hashing algorithm, then you can provide a tuple `(hashfun, targethex)`
-        - `hashfun` should be a function which takes an IOStream, and returns a `Vector{UInt8}`.
-	      - Such as any of the functions from [SHA.jl](https://github.com/staticfloat/SHA.jl), eg `sha3_384`, `sha1_512`
-	      - or `md5` from [MD5.jl](https://github.com/oxinabox/MD5.jl)
-  - If you want to use a different hashing algorithm, but don't know the sum, you can provide just the `hashfun` and a warning message will be displayed, giving the correct tuple of `(hashfun, targethex)` that should be added to the registration block.
-	- If you don't want to provide a checksum,  because your data can change pass in the type `Any` which will suppress the warning messages. (But see above warnings about "what if my data is dynamic")
-    - Can take a vector of checksums, being one for each file, or a single checksum in which case the per file hashes are `xor`ed to get the target hash. (See [Recursive Structure](@ref))
+ - `hash`: used to check whether the files downloaded correctly
+    - By far the most common use is to just provide a SHA256 sum as a hex-string for the files.
+    - If not provided, then a warning message with the  SHA256 sum is displayed. This is to help package devs work out the sum for their files, without using an external tool. You can also calculate it using [Preupload Checking](@ref).
+    - If you want to use a different hashing algorithm, then you can provide a tuple `(hashfun, targethex)`.
+      `hashfun` should be a function which takes an `IOStream`, and returns a `Vector{UInt8}`.
+      Such as any of the functions from [SHA.jl](https://github.com/staticfloat/SHA.jl), eg `sha3_384`, `sha1_512`
+      or `md5` from [MD5.jl](https://github.com/oxinabox/MD5.jl)
+    - If you want to use a different hashing algorithm, but don't know the sum, you can provide just the `hashfun` and a warning message will be displayed, giving the correct tuple of `(hashfun, targethex)` that should be added to the registration block.
+    - If you don't want to provide a checksum,  because your data can change pass in the type `Any` which will suppress the warning messages. (But see above warnings about "what if my data is dynamic").
+    - Can take a vector of checksums, being one for each file, or a single checksum in which case the per file hashes are `xor`ed to get the target hash. (See [Recursive Structure](@ref) below).
 
 
- -  `fetch_method=fetch_default` a function to run to download the files.
-    - Function should take 2 parameters `(remote_filepath, local_directorypath)`, and can must return the local filepath to the file downloaded
+ -  `fetch_method=fetch_default`: a function to run to download the files
+    - Function should take 2 parameters `(remote_filepath, local_directorypath)`, and can must return the local filepath to the file downloaded.
     - Default (`fetch_default`) can correctly handle strings containing HTTP[S] URLs, or any `remote_path` type which overloads `Base.basename` and `Base.download`, e.g. [`AWSS3.S3Path`](https://github.com/JuliaCloud/AWSS3.jl/).
-    - Can take a vector of methods, being one for each file, or a single method, in which case that method is used to download all of them. (See [Recursive Structure](@ref) below)
-	- Overloading this lets you change things about how the download is done -- the transport protocol.
-	- The default is suitable for HTTP[/S], without auth. Modifying it can add authentication or an entirely different protocol (e.g. git, google drive etc)
-	- This function is also responsible for workout out what the local file should be called (as this is protocol dependent)
+    - Can take a vector of methods, being one for each file, or a single method, in which case that method is used to download all of them. (See [Recursive Structure](@ref) below).
+    - Overloading this lets you change things about how the download is done -- the transport protocol.
+    - The default is suitable for HTTP[/S], without auth. Modifying it can add authentication or an entirely different protocol (e.g. git, google drive etc).
+    - This function is also responsible to work out what the local file should be called (as this is protocol dependent).
 	
 	
- - `post_fetch_method` a function to run after the files have download
+ - `post_fetch_method`: a function to run after the files have been downloaded
     - Should take the local filepath as its first and only argument. Can return anything.
     - Default is to do nothing.
-    - Can do what it wants from there, but most likes wants to extract the file into the data directory.
-    - towards this end DataDeps includes a command: `unpack` which will extract an compressed folder, deleting the original.
-    - It should be noted that it `post_fetch_method` runs from within the data directory
+    - Can do what it wants from there, but most likely wants to extract the file into the data directory.
+    - towards this end DataDeps.jl includes a command: `unpack` which will extract an compressed folder, deleting the original.
+    - It should be noted that `post_fetch_method` runs from within the data directory.
        - which means operations that just write to the current working directory (like `rm` or `mv` or ```run(`SOMECMD`))``` just work.
-       - You can call `cwd()` to get the the data directory for your own functions. (Or `dirname(local_filepath)`)
-    - Can take a vector of methods, being one for each file, or a single method, in which case that ame method is applied to all of the files. (See [Recursive Structure](@ref))
+       - You can call `cwd()` to get the the data directory for your own functions. (Or `dirname(local_filepath)`).
+    - Can take a vector of methods, being one for each file, or a single method, in which case that same method is applied to all of the files. (See [Recursive Structure](@ref) below).
     - You can check this as part of [Preupload Checking](@ref).
 
 
@@ -153,7 +154,7 @@ If `remote_path` is just an single path, then they each must be single items.
 If `remote_path` is a vector, then if those properties are a vector (which must be the same length) then they are applied each to the corresponding element; or if not then it is applied to all of them.
 This means you can for example provide check-sums per file, or per-the-all.
 It also means you can specify different `post_fetch_methods` for different files, e.g. doing nothing to some, and extracting others.
-Further more this applies recursively.
+Furthermore this applies recursively.
 
 For example:
 ```
@@ -162,16 +163,16 @@ register(DataDep("eg", "eg message",
     post_fetch_method = [identity, file->run(`unzip $file`), file->run(`unzip $file`)]
 ))
 ```
-So `identity`  (i.e. nothing) will be done to the first paths resulting file, and the second and third will be unzipped.
+So `identity` (i.e. nothing) will be done to the first file resulting from `remote_path`, while the second and third will be unzipped.
 
-can also be written:
+This could also be written like this:
 ```
 register(DataDep("eg", "eg message",
     ["http//example.com/text.txt", ["http//example.com/sub1.zip", "http//example.com/sub2.zip"]]
     post_fetch_method = [identity, file->run(`unzip $file`)]
 ))
 ```
-The unzip will be applied to both elements in the child array
+The unzip will be applied to both elements in the child array (i.e. the second element of `remote_path`).
 
 
 
@@ -183,15 +184,15 @@ As mentions above, if you put the data in your git repo for your package under `
 A manual DataDep registration is just like a normal `DataDep` registration,
 except that only a `name` and `message` are provided.
 Inside the message you should give instructions on how to acquire the data.
-Again see the [examples](#examples)
+Again see the [examples](#examples).
 
 
 
 ### DataDepsGenerators
 [DataDepsGenerators.jl](https://github.com/oxinabox/DataDepsGenerators.jl) is a julia package to help generate DataDeps registration blocks from well-known data sources.
-It attempts to use webscraping and such to workout what should be in the registration block.
+It attempts to use webscraping and such to figure out what should be in the registration block.
 You can then edit the generated code to make it suitable for your use.
-(E.g. remove excessive information in the message)
+(E.g. remove excessive information in the message).
 
 ## Assuming direct control and customization
 The hierachy of methods for acquiring a datadep is:
@@ -199,7 +200,7 @@ The hierachy of methods for acquiring a datadep is:
 `datadep"name/path"` ▶ `resolve("name/path", @__FILE__)` ▶ `resolve(::AbstractDataDep, "name", @__FILE__)` ▶ `download(::DataDep)`
 
 One can make use of this at various levels to override the default generally sane behavior.
-Most of the time you shouldn't have to -- the normal point of customization is in setting the `post_fetch_method`, and occasionally `fetch_method` or  `hash=(hashmethod, key)`.
+Most of the time you shouldn't have to -- the normal point of customization is in setting the `post_fetch_method`, and occasionally `fetch_method` or  `hash=(hashfun, targethex)`.
 
 
 ## `download` for low-level programmatic resolution.
@@ -247,7 +248,7 @@ then we would do so by calling `preupload_check`, passing in the DataDep name, a
 ```
 julia> preupload_check("UCI Banking", "./bank.zip")
 ┌ Warning: Checksum not provided, add to the Datadep Registration the following hash line
-│   hash = "\"99d7e8eb12401ed278b793984423915411ea8df099e1795f9fefe254f513fe5e\""
+│   hash = "99d7e8eb12401ed278b793984423915411ea8df099e1795f9fefe254f513fe5e"
 └ @ DataDeps D:\White\Documents\GitHub\DataDeps.jl\src\verification.jl:44
 
 7-Zip [64] 16.04 : Copyright (c) 1999-2016 Igor Pavlov : 2016-10-04

--- a/docs/src/z20-for-pkg-devs.md
+++ b/docs/src/z20-for-pkg-devs.md
@@ -1,7 +1,7 @@
 # Usage for developers (including researchers)
 
 ## Examples
- - [The aformentioned blog post](http://white.ucc.asn.au/2018/01/18/DataDeps.jl-Repeatabled-Data-Setup-for-Repeatable-Science.html)
+ - [The aforementioned blog post](http://white.ucc.asn.au/2018/01/18/DataDeps.jl-Repeatabled-Data-Setup-for-Repeatable-Science.html)
  - [Examples in the test code](https://github.com/oxinabox/DataDeps.jl/blob/master/test/examples.jl)
  - [Manual examples from the test code](https://github.com/oxinabox/DataDeps.jl/blob/master/test/examples_manual.jl)
 
@@ -22,13 +22,13 @@ For any registered DataDep (see below), `datadep"Name"`, returns a path to a fol
 If when that string macro is evaluated no such folder exists, then DataDeps will swing into action and coordinate the acquisition of the data into a folder, then return the path that now contains the data.
 
 You can also use `datadep"Name/subfolder/file.txt"` (and similar) to get a path to the file at  `subfolder/file.txt` within the data directory for `Name`.
-Just like when using the plain `datadep"Name"` this will if required downloadload the whole datadep (**not** just the file).
+Just like when using the plain `datadep"Name"` this will if required download the whole datadep (**not** just the file).
 However, it will also engage additional features to verify that that file exists (and is readable),
 and if not will attempt to help the user resolve the situation.
 This is useful if files may have been deleted by mistake, or if a `ManualDataDep` might have been incorrectly installed.
 
 
-#### Advanced: Programtic resolution
+#### Advanced: Programmatic resolution
 If your datadep name (or path) is in a variable (called `namepath` say)  you can use
 
 ```
@@ -55,9 +55,9 @@ data_folder = training_mode ? datadep"SecurityFootage" : "/srv/webcam/today"
 The data will not be downloaded if `training_mode==false`, because the referred to folder is never required.
 Of-course if the data was already downloaded, then it wouldn't be downloaded again either way.
 
-Another example of a particularly nice way of doing this is to use the datadep string as the default value for a function paramater
+Another example of a particularly nice way of doing this is to use the datadep string as the default value for a function parameter
 `function predict(path=datadep"SecurityFootage")`.
-If the user passses a value when they call `predict` then the datadep string will never be evaluated.
+If the user passes a value when they call `predict` then the datadep string will never be evaluated.
 So the data will not be sourced via DataDeps.jl
 
 
@@ -79,19 +79,19 @@ If you do do this, you will need to ensure the registration code is specified in
 ## Registering a DataDep
 When we say registering a DataDep we do not mean a centralised universal shared registry.
 Registering simply means defining the specifics of the DataDep in your code.
-This is done in a declaritive manner.
+This is done in a declarative manner.
 
 A DataDeps registration is a block of code declaring a dependency.
 You should put it somewhere that it will be executed before any other code in your script that depends on that data.
-In most cases it is best to put it inside the  [modules's `__init__()` function](https://docs.julialang.org/en/latest/manual/modules/#Module-initialization-and-precompilation-1).
-Note that `include` works weirdly when called inside a function, so if you want to put the registration block in another file that you `include`, you are best off either defininte `__init__` in that file, or defining a function (e.g `init_data()`) which will be called by `__init__`.
+In most cases it is best to put it inside the  [module's `__init__()` function](https://docs.julialang.org/en/latest/manual/modules/#Module-initialization-and-precompilation-1).
+Note that `include` works weirdly when called inside a function, so if you want to put the registration block in another file that you `include`, you are best off either defining `__init__` in that file, or defining a function (e.g `init_data()`) which will be called by `__init__`.
 
 
 To do the actual registration one just  calls `register(::AbstractDataDep)`.
 The rest of this section is basically about the constructors for the `DataDep` type.
 It is pretty flexible. Best is to see the examples above.
 
-The basic Registration block looks like: (Type parameters are shown below are a simplifaction)
+The basic Registration block looks like: (Type parameters are shown below are a simplification)
 ```
 register(DataDep(
     name::String,
@@ -107,7 +107,7 @@ register(DataDep(
 ### Required Fields
 
  - `name`: the name used to refer to this datadep
-    - Coresponds to a folder name where the datatep will be stored.
+    - Corresponds to a folder name where the datatep will be stored.
     - It can have spaces or any other character that is allowed in a Windows filestring (which is a strict subset of the restriction for unix filenames).
  - `message`: a message displayed to the user for they are asked if they want to download it
     - This is normally used to give a link to the original source of the data, a paper to be cited etc.
@@ -178,8 +178,8 @@ The unzip will be applied to both elements in the child array (i.e. the second e
 
 ### ManualDataDep
 ManualDataDeps are datadeps that have to be managed by some means outside of DataDeps.jl,
-but DataDeps.jl will still provide the convient `datadep"MyData"` string macro for finding them.
-As mentions above, if you put the data in your git repo for your package under `deps/data/NAME` then it will be managed by julia package manager.
+but DataDeps.jl will still provide the convenient `datadep"MyData"` string macro for finding them.
+As mentioned above, if you put the data in your git repo for your package under `deps/data/NAME` then it will be managed by julia package manager.
 
 A manual DataDep registration is just like a normal `DataDep` registration,
 except that only a `name` and `message` are provided.
@@ -195,7 +195,7 @@ You can then edit the generated code to make it suitable for your use.
 (E.g. remove excessive information in the message).
 
 ## Assuming direct control and customization
-The hierachy of methods for acquiring a datadep is:
+The hierarchy of methods for acquiring a datadep is:
 
 `datadep"name/path"` ▶ `resolve("name/path", @__FILE__)` ▶ `resolve(::AbstractDataDep, "name", @__FILE__)` ▶ `download(::DataDep)`
 
@@ -214,7 +214,7 @@ It is fully documented in its docstring.
 ## Preupload Checking
 
 Preupload checking exists to help package developers check their DataDeps on local files before they upload them.
-It checks the **checksum** is filled in and matchs, and that the `post_fetch_method` can be run without throwing any exceptions.
+It checks the **checksum** is filled in and matches, and that the `post_fetch_method` can be run without throwing any exceptions.
 
 For example, if I wished to check the UCI banking data, from a local file called `bank.zip`,
 with the registration as below:
@@ -242,7 +242,7 @@ register(
 );
 ```
 
-then we would do so by calling `preupload_check`, passing in the DataDep name, and the local file.
+Then we would do so by calling `preupload_check`, passing in the DataDep name, and the local file.
 
 
 ```

--- a/docs/src/z20-for-pkg-devs.md
+++ b/docs/src/z20-for-pkg-devs.md
@@ -123,7 +123,7 @@ register(DataDep(
       Such as any of the functions from [SHA.jl](https://github.com/staticfloat/SHA.jl), eg `sha3_384`, `sha1_512`
       or `md5` from [MD5.jl](https://github.com/oxinabox/MD5.jl)
     - If you want to use a different hashing algorithm, but don't know the sum, you can provide just the `hashfun` and a warning message will be displayed, giving the correct tuple of `(hashfun, targethex)` that should be added to the registration block.
-    - If you don't want to provide a checksum,  because your data can change pass in the type `Any` which will suppress the warning messages. (But see above warnings about "what if my data is dynamic").
+    - If you don't want to provide a checksum,  because your data can change pass in the type `Any` which will suppress the warning messages. (See above warnings about [But my data is dynamic](@ref)).
     - Can take a vector of checksums, being one for each file, or a single checksum in which case the per file hashes are `xor`ed to get the target hash. (See [Recursive Structure](@ref) below).
 
 

--- a/docs/src/z20-for-pkg-devs.md
+++ b/docs/src/z20-for-pkg-devs.md
@@ -28,7 +28,7 @@ and if not will attempt to help the user resolve the situation.
 This is useful if files may have been deleted by mistake, or if a `ManualDataDep` might have been incorrectly installed.
 
 
-#### Advanced: Programtic resolution 
+#### Advanced: Programtic resolution
 If your datadep name (or path) is in a variable (called `namepath` say)  you can use
 
 ```
@@ -50,7 +50,7 @@ For example, say some webcam security system can be run in training mode, in whi
 or in deployment mode, in which case the data should be read from the webcam's folder:
 
 ```
-data_folder = training_mode ? datadep"SecurityFootage" : "/srv/webcam/today"       
+data_folder = training_mode ? datadep"SecurityFootage" : "/srv/webcam/today"
 ```
 The data will not be downloaded if `training_mode==false`, because the referred to folder is never required.
 Of-course if the data was already downloaded, then it wouldn't be downloaded again either way.
@@ -134,8 +134,8 @@ register(DataDep(
     - Overloading this lets you change things about how the download is done -- the transport protocol.
     - The default is suitable for HTTP[/S], without auth. Modifying it can add authentication or an entirely different protocol (e.g. git, google drive etc).
     - This function is also responsible to work out what the local file should be called (as this is protocol dependent).
-	
-	
+
+
  - `post_fetch_method`: a function to run after the files have been downloaded
     - Should take the local filepath as its first and only argument. Can return anything.
     - Default is to do nothing.

--- a/docs/src/z30-for-contributors.md
+++ b/docs/src/z30-for-contributors.md
@@ -17,5 +17,5 @@ The code for `ManualDataDep` is a good place to start looking to see how that is
 You can also encapsulate an `DataDep` as one of the elements of your new type.
 
 If you do this you might like to contribute the type back up to this repository, so others can use it also.
-Particularly, if it is something that generalises beyond your specific usecase.
+Particularly, if it is something that generalises beyond your specific use case.
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -32,53 +32,55 @@ DataDep(
     name::String,
     message::String,
     remote_path::Union{String,Vector{String}...},
-    [checksum::Union{String,Vector{String}...},]; # Optional, if not provided will generate
+    [hash::Union{String,Vector{String}...},]; # Optional, if not provided will generate
     # keyword args (Optional):
-    fetch_method=fetch_default # (remote_filepath, local_directory)->local_filepath
+    fetch_method=fetch_default # (remote_filepath, local_directory_path)->local_filepath
     post_fetch_method=identity # (local_filepath)->Any
 )
 ```
 
-#### Required Fields
+### Required Fields
 
- - *Name**: the name used to refer to this datadep, coresponds to a folder name where it will be stored
+ - `name`: the name used to refer to this datadep
+    - Corresponds to a folder name where the datatep will be stored.
     - It can have spaces or any other character that is allowed in a Windows filestring (which is a strict subset of the restriction for unix filenames).
- - *Message*: A message displayed to the user for they are asked if they want to downloaded it.
+ - `message`: a message displayed to the user for they are asked if they want to download it
     - This is normally used to give a link to the original source of the data, a paper to be cited etc.
- - *remote_path*: where to fetch the data from. Normally a string or strings) containing an URL
-    - This is usually a string, or a vector of strings (or a vector of vector... see [Recursive Structure](Recursive Structure) below)
+ - `remote_path`: where to fetch the data from
+    - This is usually a string, or a vector of strings (or a vector of vectors... see [Recursive Structure](@ref) in the documentation for developers).
 
-#### Optional Fields
- - *checksum* this is very flexible, it is used to check the files downloaded correctly
-    - By far the most common use is to just provide a SHA256 sum as a hex-string for the files
-    - If not provided, then a warning message with the  SHA256 sum is displayed. This is to help package devs work out the sum for their files without using an external tool.
-    - If you want to use a different hashing algorithm, then you can provide a tuple `(hashfun, targethex)`
-        - `hashfun` should be a function which takes an IOStream, and returns a `Vector{UInt8}`.
-          - Such as any of the functions from [SHA.jl](https://github.com/staticfloat/SHA.jl), eg `sha3_384`, `sha1_512`
-          - or `md5` from [MD5.jl](https://github.com/oxinabox/MD5.jl)
-  - If you want to use a different hashing algorithm, but don't know the sum, you can provide just the `hashfun` and a warning message will be displayed, giving the correct tuple of `(hashfun, targethex)` that should be added to the registration block.
+### Optional Fields
+ - `hash`: used to check whether the files downloaded correctly
+    - By far the most common use is to just provide a SHA256 sum as a hex-string for the files.
+    - If not provided, then a warning message with the  SHA256 sum is displayed. This is to help package devs work out the sum for their files, without using an external tool. You can also calculate it using [Preupload Checking](@ref) in the documentation for developers.
+    - If you want to use a different hashing algorithm, then you can provide a tuple `(hashfun, targethex)`.
+      `hashfun` should be a function which takes an `IOStream`, and returns a `Vector{UInt8}`.
+      Such as any of the functions from [SHA.jl](https://github.com/staticfloat/SHA.jl), eg `sha3_384`, `sha1_512`
+      or `md5` from [MD5.jl](https://github.com/oxinabox/MD5.jl)
+    - If you want to use a different hashing algorithm, but don't know the sum, you can provide just the `hashfun` and a warning message will be displayed, giving the correct tuple of `(hashfun, targethex)` that should be added to the registration block.
+    - If you don't want to provide a checksum,  because your data can change pass in the type `Any` which will suppress the warning messages. (But see above warnings about "what if my data is dynamic").
+    - Can take a vector of checksums, being one for each file, or a single checksum in which case the per file hashes are `xor`ed to get the target hash. (See [Recursive Structure](@ref) in the documentation for developers).
 
-    - If you don't want to provide a checksum,  because your data can change pass in the type `Any` which will suppress the warning messages. (But see above warnings about "what if my data is dynamic")
-    - Can take a vector of checksums, being one for each file, or a single checksum in which case the per file hashes are `xor`ed to get the target hash. (See [Recursive Structure](Recursive Structure) below)
+
+ -  `fetch_method=fetch_default`: a function to run to download the files
+    - Function should take 2 parameters `(remote_filepath, local_directorypath)`, and can must return the local filepath to the file downloaded.
+    - Default (`fetch_default`) can correctly handle strings containing HTTP[S] URLs, or any `remote_path` type which overloads `Base.basename` and `Base.download`, e.g. [`AWSS3.S3Path`](https://github.com/JuliaCloud/AWSS3.jl/).
+    - Can take a vector of methods, being one for each file, or a single method, in which case that method is used to download all of them. (See [Recursive Structure](@ref) in the documentation for developers).
+    - Overloading this lets you change things about how the download is done -- the transport protocol.
+    - The default is suitable for HTTP[/S], without auth. Modifying it can add authentication or an entirely different protocol (e.g. git, google drive etc).
+    - This function is also responsible to work out what the local file should be called (as this is protocol dependent).
 
 
- -  `fetch_method=fetch_default` a function to run to download the files.
-    - Function should take 2 parameters (remotepath, local_directory), and must return a local filepath
-    - It is responsible for determining what the local filename should be
-    - Change this to change the transfer protocol, for example to use an auth'ed connection.
-    - Default `fetch_default` which fully supports HTTP, and has fallbacks to support any type which overloads `Base.basename` and `Base.download` (see [`fetch_base`](@ref))
-    - Can take a vector of methods, being one for each file, or a single method, in which case that method is used to download all of them. (See [Recursive Structure](Recursive Structure) below)
-    - Very few people will need to override this if they are just downloading public HTTP files.
-
- - `post_fetch_method` a function to run after the files have download
+ - `post_fetch_method`: a function to run after the files have been downloaded
     - Should take the local filepath as its first and only argument. Can return anything.
     - Default is to do nothing.
-    - Can do what it wants from there, but most likes wants to extract the file into the data directory.
-    - towards this end DataDeps includes a command: `unpack` which will extract an compressed folder, deleting the original.
-    - It should be noted that it `post_fetch_method` runs from within the data directory
+    - Can do what it wants from there, but most likely wants to extract the file into the data directory.
+    - towards this end DataDeps.jl includes a command: `unpack` which will extract an compressed folder, deleting the original.
+    - It should be noted that `post_fetch_method` runs from within the data directory.
        - which means operations that just write to the current working directory (like `rm` or `mv` or ```run(`SOMECMD`))``` just work.
-       - You can call `cwd()` to get the the data directory for your own functions. (Or `dirname(local_filepath)`)
-    - Can take a vector of methods, being one for each file, or a single method, in which case that ame method is applied to all of the files. (See **Recursive Structure** in the README.md)
+       - You can call `cwd()` to get the the data directory for your own functions. (Or `dirname(local_filepath)`).
+    - Can take a vector of methods, being one for each file, or a single method, in which case that same method is applied to all of the files. (See [Recursive Structure](@ref) in the documentation for developers).
+    - You can check this as part of [Preupload Checking](@ref) in the documentation for developers.
 """
 function DataDep(name::String,
                  message::String,


### PR DESCRIPTION
- [x] Fix some typos
- [x] Replace `checksum` by `hash`
- [x] Fix docstring of [`DataDep`](https://github.com/oxinabox/DataDeps.jl/blob/master/src/types.jl#L29-L82) constructor. Is it somehow possible to splice that into the dev docs page (to keep it dry)?
- [x] Fix headings of index page
- [x] Create hyperlink to "what if my data is dynamic" on the index page

Close #112