### PR TITLE
allow HTTP 0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDeps"
 uuid = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
 authors = ["Frames White <oxinabox@ucc.asn.au>"]
-version = "0.7.9"
+version = "0.7.10"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
@@ -14,7 +14,7 @@ p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 [compat]
 BinaryProvider = "0.5"
 ExpectationStubs = "0.2"
-HTTP = "1"
+HTTP = "0.9, 1"
 Reexport = "0.2, 1.0"
 julia = "1"
 p7zip_jll = "16.2.0, 17"


### PR DESCRIPTION
Follow up to #157  since i realised that HTTP 1.0 doesn't support Julia 1.0
cc @chengchingwen 