### PR TITLE
use .julia/scratchspaces instead of .julia/datadeps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,14 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [compat]
 ExpectationStubs = "0.2"
 HTTP = "1"
 Reexport = "0.2, 1.0"
+Scratch = "1"
 julia = "1.6"
 p7zip_jll = "16.2.0, 17"
 

--- a/docs/src/z10-for-end-users.md
+++ b/docs/src/z10-for-end-users.md
@@ -7,8 +7,8 @@ Moving data is a great idea.
 DataDeps.jl is in favour of moving data.
 When data is automatically downloaded it will almost always go to the same location:
 the first (existent, writable) directory on your `DATADEPS_LOAD_PATH`.
-Which by-default is `~/.julia/datadeps/`.
-(If you delete this, it will go to another location).
+Which by-default is DataDeps's scratch space under `~/.julia/scratchspaces/124859b0-ceae-595e-8997-d05f6a7a8dfe/datadeps`,
+such that `Pkg.gc()` can automatically delete data if DataDeps is uninstalled.
 But you can move them from there to anywhere in the `DATADEPS_LOAD_PATH`. (See below)
 
 If you have a large chunk of data that everyone in your lab is using (e.g. a 1TB video corpora),
@@ -47,7 +47,7 @@ You can (and should when desired) move things around between any folder in the l
 For the user **oxinabox**
 
 ```bash
-/home/wheel/oxinabox/.julia/datadeps
+/home/wheel/oxinabox/.julia/scratchspaces/124859b0-ceae-595e-8997-d05f6a7a8dfe/datadeps
 /home/wheel/oxinabox/datadeps
 /scratch/datadeps
 /staging/datadeps

--- a/src/DataDeps.jl
+++ b/src/DataDeps.jl
@@ -4,6 +4,7 @@ using p7zip_jll
 
 using HTTP
 using Reexport
+using Scratch
 @reexport using SHA
 
 export DataDep, ManualDataDep

--- a/src/DataDeps.jl
+++ b/src/DataDeps.jl
@@ -35,6 +35,7 @@ datadeps_scratch_dir = ""
 
 function __init__()
     global datadeps_scratch_dir =  @get_scratch!("datadeps")
+    pushfirst!(standard_loadpath, datadeps_scratch_dir)
 end
 
 function _precompile_()

--- a/src/DataDeps.jl
+++ b/src/DataDeps.jl
@@ -30,6 +30,12 @@ include("preupload.jl")
 include("fetch_helpers.jl")
 include("post_fetch_helpers.jl")
 
+# populated by __init__()
+datadeps_scratch_dir = ""
+
+function __init__()
+    global datadeps_scratch_dir =  @get_scratch!("datadeps")
+end
 
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing

--- a/src/locations.jl
+++ b/src/locations.jl
@@ -2,7 +2,7 @@
 ## Core path determining stuff
 
 const standard_loadpath = joinpath.([
-    Base.DEPOT_PATH; homedir(); # Common all systems
+    homedir(); # Common all systems
 
     @static if Sys.iswindows()
         vcat(get.(Ref(ENV),
@@ -14,6 +14,16 @@ const standard_loadpath = joinpath.([
         ["/scratch", "/staging", # HPC common folders
          "/usr/share", "/usr/local/share"] # Unix Filestructure
     end], "datadeps")
+
+if VERSION > v"1.6.0-0"
+    # Scratch.jl works correctly with Julia 1.0 and above.
+    # However, Pkg's built-in garbage collection, i.e. Pkg.gc(), is only aware of
+    # scratchspaces for Julia 1.6 and above so use the more user accessible DEPOT/datadeps location
+    # for visibility to the user for space management
+    pushfirst!(standard_loadpath, @get_scratch!("datadeps"))
+else
+    pushfirst!(standard_loadpath, joinpath(Base.DEPOT_PATH, "datadeps"))
+end
 
 # ensure at least something in the loadpath exists when instaleld
 mkpath(first(standard_loadpath))

--- a/src/locations.jl
+++ b/src/locations.jl
@@ -20,7 +20,7 @@ if VERSION > v"1.6.0-0"
     # However, Pkg's built-in garbage collection, i.e. Pkg.gc(), is only aware of
     # scratchspaces for Julia 1.6 and above so use the more user accessible DEPOT/datadeps location
     # for visibility to the user for space management
-    pushfirst!(standard_loadpath, @get_scratch!("datadeps"))
+    pushfirst!(standard_loadpath, datadeps_scratch_dir)
 else
     pushfirst!(standard_loadpath, joinpath(Base.DEPOT_PATH, "datadeps"))
 end

--- a/src/locations.jl
+++ b/src/locations.jl
@@ -15,7 +15,8 @@ const standard_loadpath = joinpath.([
          "/usr/share", "/usr/local/share"] # Unix Filestructure
     end], "datadeps")
 
-pushfirst!(standard_loadpath, joinpath(Base.DEPOT_PATH, "datadeps"))
+# NOTE: the scratchspace is pushed to the front during __init__()
+
 
 # ensure at least something in the loadpath exists when instaleld
 mkpath(first(standard_loadpath))

--- a/src/locations.jl
+++ b/src/locations.jl
@@ -15,15 +15,7 @@ const standard_loadpath = joinpath.([
          "/usr/share", "/usr/local/share"] # Unix Filestructure
     end], "datadeps")
 
-if VERSION > v"1.6.0-0"
-    # Scratch.jl works correctly with Julia 1.0 and above.
-    # However, Pkg's built-in garbage collection, i.e. Pkg.gc(), is only aware of
-    # scratchspaces for Julia 1.6 and above so use the more user accessible DEPOT/datadeps location
-    # for visibility to the user for space management
-    pushfirst!(standard_loadpath, datadeps_scratch_dir)
-else
-    pushfirst!(standard_loadpath, joinpath(Base.DEPOT_PATH, "datadeps"))
-end
+pushfirst!(standard_loadpath, joinpath(Base.DEPOT_PATH, "datadeps"))
 
 # ensure at least something in the loadpath exists when instaleld
 mkpath(first(standard_loadpath))


### PR DESCRIPTION
Closes https://github.com/oxinabox/DataDeps.jl/issues/135

Helps avoid having to do special handling in tooling like https://github.com/julia-actions/cache/issues/80