### PR TITLE
Fix CI

### DIFF
--- a/test/examples.jl
+++ b/test/examples.jl
@@ -29,7 +29,7 @@ end
 
     Used under Creative Commons Attribution 4.0 International License.
     """,
-    "https://raw.githack.com/fivethirtyeight/data/master/trump-twitter/realDonaldTrump_poll_tweets.csv",
+    "https://rawcdn.githack.com/fivethirtyeight/data/f8c2c4beab87e21fe05d5559d0db2a1051c28abe/trump-twitter/realDonaldTrump_poll_tweets.csv",
     "5a63b6cb2503a20517b5d41bd73e821ffbfdddd5cdc1977a547f1c925790bb15",
     post_fetch_method = function(in_fn) # Multiline anon function.
         out_fn = "nonmentions_"*basename(in_fn)

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -2,8 +2,6 @@ using Test
 using DataDeps
 using DelimitedFiles
 
-ENV["DATADEPS_ALWAYS_ACCEPT"] = true
-
 @testset "Pi" begin
     register(DataDep(
      "Pi",

--- a/test/fetch_helpers.jl
+++ b/test/fetch_helpers.jl
@@ -1,8 +1,6 @@
 using Test
 using DataDeps: fetch_default, fetch_base, fetch_http
 
-ENV["DATADEPS_ALWAYS_ACCEPT"] = true
-
 @testset "easy https url" begin
     url = "https://www.angio.net/pi/digits/10000.txt"
     # This is easy because the filename is in the URL
@@ -10,7 +8,9 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
     # HTTP.jl has tests for much more difficult cases, and fetch_http supports those
     @testset "$fetch_func" for fetch_func in (fetch_default, fetch_base, fetch_http)
         mktempdir() do localdir
-            localpath = fetch_func(url, localdir)
+            localpath = withenv("DATADEPS_ALWAYS_ACCEPT" => true) do
+                fetch_func(url, localdir)
+            end
             @test isfile(localpath)
             @test localpath == joinpath(localdir, "10000.txt")
             @test stat(localpath).size == 10_001

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ using Test
 
     @testset "examples" for fn in examples
         @testset "$fn" begin
+            curdir = pwd()
             tempdir = mktempdir()
             try
                 @info("sending all datadeps to $tempdir")
@@ -43,7 +44,7 @@ using Test
             finally
                 try
                     @info("removing $tempdir")
-                    cd(@__DIR__)  # Ensure not currently in directory being deleted
+                    cd(curdir)  # Ensure not currently in directory being deleted
                     rm(tempdir, recursive=true, force=true)
                 catch err
                     @warn("Something went wrong with removing $tempdir")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,8 @@ using Test
             try
                 @info("sending all datadeps to $tempdir")
                 withenv("DATADEPS_LOAD_PATH"=>tempdir,
-                        "DATADEPS_NO_STANDARD_LOADPATH"=>true) do
+                        "DATADEPS_NO_STANDARD_LOADPATH"=>true,
+                        "DATADEPS_ALWAYS_ACCEPT" => true) do
                     @testset "download and use" begin
                         include(fn)
                     end


### PR DESCRIPTION
As noted in https://github.com/oxinabox/DataDeps.jl/pull/167#issuecomment-1836181040, CI is currently broken on master. This PR fixes CI, mostly by specifying the specific older commit of Trump tweets (they were updated 2 years ago, see https://github.com/fivethirtyeight/data/commits/master/trump-twitter/realDonaldTrump_poll_tweets.csv). It also makes minor changes to avoid permanently changing the working directory or environment when locally evaluating CI.