### PR TITLE
Add DATADEPS_ABORT_ON_ERROR to auto-abort in CI instead of prompting

### DIFF
--- a/src/resolution.jl
+++ b/src/resolution.jl
@@ -33,6 +33,9 @@ function resolve(datadep::AbstractDataDep, inner_filepath, calling_filepath)::St
             return realpath(filepath) # resolve any symlinks for maximum compatibility with external applications
         else # Something has gone wrong
             @warn("DataDep $(datadep.name) found at \"$(dirpath)\". But could not read file at \"$(filepath)\".")
+            if should_abort_on_error()
+                abort("DATADEPS_ABORT_ON_ERROR is set. Aborting after failing to read \"$(filepath)\".")
+            end
             println("Something has gone wrong. What would you like to do?")
             input_choice(
                 ('A', "Abort -- this will error out",

--- a/src/resolution_automatic.jl
+++ b/src/resolution_automatic.jl
@@ -140,6 +140,9 @@ Ensures the checksum passes, and handles the dialog with use user when it fails.
 """
 function checksum_pass(hash, fetched_path)
     if !run_checksum(hash, fetched_path)
+        if should_abort_on_error()
+            abort("DATADEPS_ABORT_ON_ERROR is set. Checksum failed for \"$(fetched_path)\".")
+        end
         reply = input_choice("Do you wish to Abort, Retry download or Ignore", 'a','r','i')
         if reply=='a'
             abort("Hash Failed, user elected not to retry")

--- a/src/resolution_manual.jl
+++ b/src/resolution_manual.jl
@@ -9,6 +9,9 @@ function handle_missing(datadep::ManualDataDep, calling_filepath)::String
           join(localpaths,", \n", ",\nor "))
     @info("by following the instructions:")
     @info(datadep.message)
+    if should_abort_on_error()
+        abort("DATADEPS_ABORT_ON_ERROR is set. ManualDataDep $(datadep.name) requires manual installation.")
+    end
     while true
         reply = input_choice("Once installed please enter 'y' reattempt loading, or 'a' to abort", 'y','a')
         if reply=='a'

--- a/src/util.jl
+++ b/src/util.jl
@@ -34,6 +34,15 @@ Checks for an environment variable and fuzzy converts it to a bool
 env_bool(key, default=false) = haskey(ENV, key) ? lowercase(ENV[key]) ∉ ["0","","false", "no"] : default
 
 """
+    should_abort_on_error()
+
+Returns true if interactive prompts should be replaced by automatic aborts.
+Controlled by `DATADEPS_ABORT_ON_ERROR` environment variable;
+defaults to the value of the `CI` environment variable.
+"""
+should_abort_on_error() = env_bool("DATADEPS_ABORT_ON_ERROR", env_bool("CI"))
+
+"""
     env_list(key)
 
 Checks for an environment variable and converts it to a list of strings, sperated with a colon

--- a/test/non_interactive.jl
+++ b/test/non_interactive.jl
@@ -1,0 +1,73 @@
+using DataDeps
+using DataDeps: should_abort_on_error, checksum_pass, UserAbortError
+using Test
+using ExpectationStubs
+
+# HACK: same as in main.jl — must be at top level in Julia 1.12+
+Base.open(stub::Stub, t::Any, ::AbstractString) = stub(t)
+
+@testset "should_abort_on_error()" begin
+    # DATADEPS_ABORT_ON_ERROR takes precedence over CI when explicitly set
+    # (both ENV vars passed to withenv to ensure clean slate)
+    @testset "DATADEPS_ABORT_ON_ERROR=$val overrides CI=$ci" for
+            (val, expected) in [("true", true), ("false", false)],
+            ci in [nothing, "true", "false"]
+        withenv("CI"=>ci, "DATADEPS_ABORT_ON_ERROR"=>val) do
+            @test should_abort_on_error() == expected
+        end
+    end
+
+    # When DATADEPS_ABORT_ON_ERROR is not set, falls back to CI
+    @testset "falls back to CI=$ci" for
+            (ci, expected) in [(nothing, false), ("true", true), ("false", false)]
+        withenv("CI"=>ci, "DATADEPS_ABORT_ON_ERROR"=>nothing) do
+            @test should_abort_on_error() == expected
+        end
+    end
+end
+
+@testset "checksum_pass aborts in non-interactive mode" begin
+    withenv("DATADEPS_ABORT_ON_ERROR"=>"true") do
+        bad_hash = "0000000000000000000000000000000000000000000000000000000000000000"
+        @test_throws UserAbortError checksum_pass(bad_hash, @__FILE__)
+    end
+end
+
+@testset "file-not-readable aborts in non-interactive mode" begin
+    withenv("DATADEPS_ABORT_ON_ERROR"=>"true",
+            "DATADEPS_ALWAYS_ACCEPT"=>"true") do
+        path_current = @__DIR__
+
+        @stub dummyhash
+        @expect(dummyhash(::Any) = [0x12, 0x34])
+
+        @stub dummydown
+        @expect(dummydown("http://www.example.com/eg.zip", ::String) = joinpath(path_current, "eg.zip"))
+
+        register(DataDep("TestAbortOnErrorRead",
+            "A dummy message",
+            "http://www.example.com/eg.zip",
+            (dummyhash, "1234"),
+            fetch_method=dummydown
+        ))
+
+        # First resolve should work (downloads to dir)
+        dirpath = datadep"TestAbortOnErrorRead"
+        @test isdir(dirpath)
+
+        # Resolving with a non-existent inner file should abort
+        @test_throws UserAbortError resolve("TestAbortOnErrorRead/nonexistent_file.txt", @__FILE__)
+
+        rm(dirpath; recursive=true)
+    end
+end
+
+@testset "ManualDataDep aborts in non-interactive mode" begin
+    withenv("DATADEPS_ABORT_ON_ERROR"=>"true") do
+        register(ManualDataDep("TestAbortOnErrorManual",
+            "Please install this manually."
+        ))
+
+        @test_throws UserAbortError datadep"TestAbortOnErrorManual"
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Test
         "main",
         "preupload",
         "fetch_helpers",
+        "non_interactive",
     ]
     @testset "tests" begin
         for filename in tests


### PR DESCRIPTION
Foreword: I used Claude for this. 

When CI=true and DATADEPS_ALWAYS_ACCEPT=true, downloads proceed but if something goes wrong (file unreadable, checksum failure, manual datadep missing), interactive prompts cause hangs and log spam since there is no stdin. This adds a DATADEPS_ABORT_ON_ERROR env var that auto-aborts instead of prompting. It defaults to the value of CI, so no extra configuration is needed for most CI setups.

Fixes #141.

Might need #180 for CI to run.