### PR TITLE
Add DATADEPS_MAX_INPUT_RETRIES to configure input retry count

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -34,14 +34,6 @@ Checks for an environment variable and fuzzy converts it to a bool
 env_bool(key, default=false) = haskey(ENV, key) ? lowercase(ENV[key]) ∉ ["0","","false", "no"] : default
 
 """
-    max_input_retries()
-
-Returns the maximum number of retries for interactive input prompts.
-Controlled by `DATADEPS_MAX_INPUT_RETRIES` environment variable; defaults to 10.
-"""
-max_input_retries() = parse(Int, get(ENV, "DATADEPS_MAX_INPUT_RETRIES", "10"))
-
-"""
     env_list(key)
 
 Checks for an environment variable and converts it to a list of strings, sperated with a colon
@@ -84,8 +76,7 @@ end
 Prompted the user for one of a list of options
 """
 function input_choice(prompt, options::Vararg{Char})::Char
-    retries = max_input_retries()
-    for _ in 1:retries
+    for _ in 1:10
         println(prompt)
         println("["*join(options, '/')*"]")
         response = better_readline()
@@ -96,7 +87,7 @@ function input_choice(prompt, options::Vararg{Char})::Char
         end
     end
     error(
-        "Either user provided invalid input $retries times; or something has " *
+        "Either user provided invalid input 10 times; or something has " *
         "gone wrong with the IO reading. Please comment on: \n\t" *
         "https://github.com/oxinabox/DataDeps.jl/issues/104"
     )

--- a/src/util.jl
+++ b/src/util.jl
@@ -34,6 +34,14 @@ Checks for an environment variable and fuzzy converts it to a bool
 env_bool(key, default=false) = haskey(ENV, key) ? lowercase(ENV[key]) ∉ ["0","","false", "no"] : default
 
 """
+    max_input_retries()
+
+Returns the maximum number of retries for interactive input prompts.
+Controlled by `DATADEPS_MAX_INPUT_RETRIES` environment variable; defaults to 10.
+"""
+max_input_retries() = parse(Int, get(ENV, "DATADEPS_MAX_INPUT_RETRIES", "10"))
+
+"""
     env_list(key)
 
 Checks for an environment variable and converts it to a list of strings, sperated with a colon
@@ -76,7 +84,8 @@ end
 Prompted the user for one of a list of options
 """
 function input_choice(prompt, options::Vararg{Char})::Char
-    for _ in 1:100
+    retries = max_input_retries()
+    for _ in 1:retries
         println(prompt)
         println("["*join(options, '/')*"]")
         response = better_readline()
@@ -87,7 +96,7 @@ function input_choice(prompt, options::Vararg{Char})::Char
         end
     end
     error(
-        "Either user provided invalid input 100 times; or something has" *
+        "Either user provided invalid input $retries times; or something has " *
         "gone wrong with the IO reading. Please comment on: \n\t" *
         "https://github.com/oxinabox/DataDeps.jl/issues/104"
     )

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,7 +1,7 @@
 using Test
 
 
-using DataDeps: env_bool
+using DataDeps: env_bool, max_input_retries
 @testset "Env Bool" begin
     withenv("A"=>"True") do
         @test env_bool("A")
@@ -21,5 +21,24 @@ using DataDeps: env_bool
 
     withenv("E"=>"1") do
         @test env_bool("E")
+    end
+end
+
+@testset "max_input_retries" begin
+    @testset "defaults to 10" begin
+        withenv("DATADEPS_MAX_INPUT_RETRIES"=>nothing) do
+            @test max_input_retries() == 10
+        end
+    end
+    @testset "respects DATADEPS_MAX_INPUT_RETRIES=$val" for
+            (val, expected) in [("3", 3), ("1", 1), ("50", 50)]
+        withenv("DATADEPS_MAX_INPUT_RETRIES"=>val) do
+            @test max_input_retries() == expected
+        end
+    end
+    @testset "errors on invalid value" begin
+        withenv("DATADEPS_MAX_INPUT_RETRIES"=>"abc") do
+            @test_throws ArgumentError max_input_retries()
+        end
     end
 end

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,7 +1,7 @@
 using Test
 
 
-using DataDeps: env_bool, max_input_retries
+using DataDeps: env_bool
 @testset "Env Bool" begin
     withenv("A"=>"True") do
         @test env_bool("A")
@@ -21,24 +21,5 @@ using DataDeps: env_bool, max_input_retries
 
     withenv("E"=>"1") do
         @test env_bool("E")
-    end
-end
-
-@testset "max_input_retries" begin
-    @testset "defaults to 10" begin
-        withenv("DATADEPS_MAX_INPUT_RETRIES"=>nothing) do
-            @test max_input_retries() == 10
-        end
-    end
-    @testset "respects DATADEPS_MAX_INPUT_RETRIES=$val" for
-            (val, expected) in [("3", 3), ("1", 1), ("50", 50)]
-        withenv("DATADEPS_MAX_INPUT_RETRIES"=>val) do
-            @test max_input_retries() == expected
-        end
-    end
-    @testset "errors on invalid value" begin
-        withenv("DATADEPS_MAX_INPUT_RETRIES"=>"abc") do
-            @test_throws ArgumentError max_input_retries()
-        end
     end
 end


### PR DESCRIPTION
The input_choice function previously looped 100 times when reading from stdin, causing excessive log spam in environments with broken or absent stdin. This reduces the default to 10 and makes it configurable via the DATADEPS_MAX_INPUT_RETRIES environment variable.

Related to #141.

Might need #180 for CI to run.