### PR TITLE
Add dependabot and modernize CI workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "julia"
-    directory: "/"
+    directories:
+      - "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,10 +6,20 @@ on:
   push:
     branches: master
     tags: "*"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      # needed to allow julia-actions/cache to proactively delete old caches that it has created
+      actions: write
+      contents: read
     strategy:
       fail-fast: true
       matrix:
@@ -32,28 +42,34 @@ jobs:
           - os: windows-latest
             arch: x86
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+        if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64' }}
+      - uses: codecov/codecov-action@v6
+        if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64' }}
         with:
           files: lcov.info
+          # Uncomment if tokenless uploads become flaky (requires CODECOV_TOKEN repo secret):
+          # token: ${{ secrets.CODECOV_TOKEN }}
+          # fail_ci_if_error: false
 
   docs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
-      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,9 +40,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-        if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
       - uses: codecov/codecov-action@v6
-        if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
         with:
           files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     permissions:
       # needed to allow julia-actions/cache to proactively delete old caches that it has created
@@ -24,7 +24,6 @@ jobs:
       fail-fast: true
       matrix:
         version:
-          - "1.6"  # previous lts, kept for backwards compatibility
           - "lts"  # Long-term support release
           - "1"    # Latest release
           # - nightly  # Note: Allow failures isn't currently supported in GitHub actions
@@ -32,56 +31,18 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
-          - x86
-        exclude:
-          # Test 32-bit only on Linux
-          - os: macOS-latest
-            arch: x86
-          - os: windows-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-        if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64' }}
+        if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
       - uses: codecov/codecov-action@v6
-        if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64' }}
+        if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
         with:
           files: lcov.info
-          # Uncomment if tokenless uploads become flaky (requires CODECOV_TOKEN repo secret):
-          # token: ${{ secrets.CODECOV_TOKEN }}
-          # fail_ci_if_error: false
-
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: "1"
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
-      - run: |
-          julia --project=docs -e '
-            using Documenter: DocMeta, doctest
-            using DataDeps
-            DocMeta.setdocmeta!(DataDeps, :DocTestSetup, :(using DataDeps); recursive=true)
-            doctest(DataDeps)'
-      - run: julia --project=docs docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -1,0 +1,48 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+      - "src/**"
+      - "*.toml"
+    tags: ["*"]
+  pull_request:
+    paths:
+      - "docs/**"
+      - "src/**"
+      - "*.toml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1"
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1
+      - run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: |
+          julia --project=docs -e '
+            using Documenter: DocMeta, doctest
+            using DataDeps
+            DocMeta.setdocmeta!(DataDeps, :DocTestSetup, :(using DataDeps); recursive=true)
+            doctest(DataDeps)'
+      - run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Modernize CI in the style of [BestieTemplate](https://github.com/JuliaBesties/BestieTemplate.jl) and add Dependabot.

- Add `.github/dependabot.yml` (weekly `github-actions` + `julia` updates)
- Bump action versions; pin `julia-buildpkg`/`julia-runtest` to `@v1` so Dependabot can track them
- Drop the `arch` matrix dimension and Julia 1.6 — fixes macOS-latest (Apple Silicon) failures with `setup-julia@v3`; `lts` is now the floor
- Split docs into `Docs.yml` with a `paths:` filter so it only runs when `docs/`, `src/`, or `*.toml` change
- Limit coverage upload to `1` + `ubuntu-latest`; uses `CODECOV_TOKEN` if set, falls back to tokenless otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)
